### PR TITLE
feat: Upgrade to gpt-5.2 with max_completion_tokens parameter

### DIFF
--- a/agents/document_agent.py
+++ b/agents/document_agent.py
@@ -116,13 +116,13 @@ class DocumentExplorationAgent:
     Autonomous agent for exploring therapy sessions and generating clinical documents.
     """
     
-    def __init__(self, openai_api_key: str, model: str = "gpt-4o"):
+    def __init__(self, openai_api_key: str, model: str = "gpt-5.2"):
         """
         Initialize the document exploration agent.
 
         Args:
             openai_api_key: OpenAI API key
-            model: Model to use (default: gpt-4o)
+            model: Model to use (default: gpt-5.2)
         """
         self.openai_api_key = openai_api_key
         self.model = model
@@ -365,7 +365,7 @@ Start exploring!"""
 _document_agent: Optional[DocumentExplorationAgent] = None
 
 
-def initialize_agent(openai_api_key: str, model: str = "gpt-4o"):
+def initialize_agent(openai_api_key: str, model: str = "gpt-5.2"):
     """Initialize the global document agent instance."""
     global _document_agent
     _document_agent = DocumentExplorationAgent(openai_api_key, model)

--- a/document_generation/generator.py
+++ b/document_generation/generator.py
@@ -204,7 +204,7 @@ Always personalize the document by using the actual client and practitioner name
         
         # Generate document using OpenAI
         response = await openai_client.chat.completions.create(
-            model="gpt-4o",
+            model="gpt-5.2",
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}

--- a/haystack_pipeline.py
+++ b/haystack_pipeline.py
@@ -101,7 +101,7 @@ class HaystackPipelineManager:
             tools=tools,  # Pass tools to the generator so it knows what's available
             generation_kwargs={
                 "temperature": persona_config.temperature,
-                "max_tokens": persona_config.max_tokens
+                "max_completion_tokens": persona_config.max_completion_tokens
             }
         ))
         pipeline.add_component("router", ConditionalRouter(routes, unsafe=True))
@@ -154,7 +154,7 @@ class HaystackPipelineManager:
             tools=tools,  # Pass tools to the generator so it knows what's available
             generation_kwargs={
                 "temperature": persona_config.temperature,
-                "max_tokens": persona_config.max_tokens
+                "max_completion_tokens": persona_config.max_completion_tokens
             }
         ))
         pipeline.add_component("router", ConditionalRouter(routes, unsafe=True))
@@ -202,7 +202,7 @@ class HaystackPipelineManager:
             tools=tools,  # Pass tools to the generator so it knows what's available
             generation_kwargs={
                 "temperature": persona_config.temperature,
-                "max_tokens": persona_config.max_tokens
+                "max_completion_tokens": persona_config.max_completion_tokens
             }
         ))
         pipeline.add_component("router", ConditionalRouter(routes, unsafe=True))

--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ async def on_startup():
     # Initialize document exploration agent
     if openai_api_key:
         try:
-            initialize_agent(openai_api_key, model="gpt-4o")
+            initialize_agent(openai_api_key, model="gpt-5.2")
             logger.info("✅ Document Exploration Agent initialized")
         except Exception as e:
             logger.error(f"❌ Failed to initialize Document Agent: {e}")
@@ -495,10 +495,10 @@ async def chat(request: ChatRequest, authorization: str = Header(None), profilei
             raise HTTPException(status_code=500, detail="OpenAI client not configured")
         
         response = await openai_client.chat.completions.create(
-            model="gpt-4o",
+            model="gpt-5.2",
             messages=messages,
             temperature=0.7,
-            max_tokens=4096
+            max_completion_tokens=4096
         )
         
         response_text = response.choices[0].message.content or ""
@@ -685,7 +685,7 @@ Respond with JSON only."""
                 {"role": "user", "content": user_prompt}
             ],
             temperature=0.1,  # Low temperature for consistent policy enforcement
-            max_tokens=200
+            max_completion_tokens=200
         )
         
         result_text = response.choices[0].message.content.strip()

--- a/personas.py
+++ b/personas.py
@@ -11,9 +11,9 @@ class PersonaConfig(BaseModel):
     name: str
     description: str
     system_prompt: str
-    model: str = "gpt-4o"
+    model: str = "gpt-5.2"
     temperature: float = 0.7
-    max_tokens: int = 1000
+    max_completion_tokens: int = 1000
     has_db_access: bool = False
     tools: List[Dict[str, Any]] = []  # OpenAI function definitions
     available_functions: Dict[str, Callable] = {}  # Function implementations
@@ -121,9 +121,9 @@ Documents: get_templates, set_selected_template, select_template_by_name, check_
 - Plan before tool calls - think through data needs and sequence
 - Accumulate modification requests across conversation
 - Be helpful, accurate, empathetic, professional""",
-                model="gpt-4o",
+                model="gpt-5.2",
                 temperature=0.7,
-                max_tokens=32768,
+                max_completion_tokens=32768,
                 has_db_access=True,
                 tools=self.tool_manager.get_tools_for_persona("web_assistant"),
                 available_functions=self.tool_manager.get_functions_for_persona("web_assistant")
@@ -160,9 +160,9 @@ Documents: get_templates, set_selected_template, select_template_by_name, check_
 - Prioritize client safety and well-being
 - Use person-first, non-judgmental language
 - Respect cultural and individual differences""",
-                model="gpt-4o",
+                model="gpt-5.2",
                 temperature=0.8,
-                max_tokens=32768,
+                max_completion_tokens=32768,
                 has_db_access=False,
                 tools=self.tool_manager.get_tools_for_persona("jaimee_therapist"),
                 available_functions=self.tool_manager.get_functions_for_persona("jaimee_therapist")
@@ -178,9 +178,9 @@ Documents: get_templates, set_selected_template, select_template_by_name, check_
 - Preserve clinical sections and headings from template
 - If content missing (no template/sessions), provide concise guidance
 - Maintain privacy; don't expose sensitive identifiers beyond template requirements""",
-                model="gpt-4o",
+                model="gpt-5.2",
                 temperature=0.7,
-                max_tokens=32768,
+                max_completion_tokens=32768,
                 has_db_access=False,
                 tools=self.tool_manager.get_tools_for_persona("transcriber_agent"),
                 available_functions=self.tool_manager.get_functions_for_persona("transcriber_agent")


### PR DESCRIPTION
## Summary
- Upgrade all models from gpt-4o to gpt-5.2
- Change `max_tokens` to `max_completion_tokens` for gpt-5.2 compatibility
- Keep gpt-4o-mini for streaming endpoints (still uses `max_tokens`)

## Files Changed
- `personas.py` - All persona models + parameter name
- `main.py` - Direct OpenAI calls
- `haystack_pipeline.py` - Pipeline generation_kwargs
- `document_generation/generator.py` - Document generation
- `agents/document_agent.py` - Agent initialization

## Test Plan
- [ ] Verify AI Assistant works in prod after deploy
- [ ] Check document generation