### PR TITLE
fix: robust generated-document lookup across sessions

### DIFF
--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -38,50 +38,39 @@ jobs:
         mkdir deploy
         
         # Copy application source
-        cp main.py deploy/
-        cp config.py deploy/
-        cp personas.py deploy/
-        cp session_manager.py deploy/
-        cp haystack_pipeline.py deploy/
-        cp ui_state_manager.py deploy/
-        cp tools.py deploy/
-        cp requirements.txt deploy/
-        cp -r components deploy/
-        cp -r agents deploy/
-        cp -r document_generation deploy/
-        cp -r utils deploy/
+        cp main.py config.py personas.py session_manager.py haystack_pipeline.py \
+           ui_state_manager.py tools.py requirements.txt startup.sh deploy/
+        cp -r components agents document_generation utils deploy/
         
         # Verify main.py is present
-        if [ ! -f deploy/main.py ]; then
-          echo "ERROR: main.py not found!"
-          exit 1
-        fi
+        test -f deploy/main.py || { echo "ERROR: main.py not found!"; exit 1; }
         
-        # Build venv with all dependencies (runs on Ubuntu, same as Azure Linux)
+        # Build venv with all dependencies (Ubuntu runner matches Azure Linux)
         python -m venv deploy/antenv
-        deploy/antenv/bin/pip install --no-cache-dir -r requirements.txt
+        deploy/antenv/bin/pip install --no-cache-dir -q -r requirements.txt
         
-        # Verify key packages installed
+        # Verify key packages
         deploy/antenv/bin/python -c "import fastapi; import openai; import haystack; print('All packages OK')"
         
-        # Create simple startup script
-        cat > deploy/startup.sh << 'STARTUP'
-        #!/bin/bash
-        cd /home/site/wwwroot
-        export HOST=${HOST:-0.0.0.0}
-        export PORT=${PORT:-8001}
-        echo "[startup] Starting Uvicorn on $HOST:$PORT"
-        exec antenv/bin/python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
-        STARTUP
-        chmod +x deploy/startup.sh
+        # Strip unnecessary files to reduce package size
+        find deploy/antenv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+        find deploy/antenv -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true
+        find deploy/antenv -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+        find deploy/antenv -name "*.pyc" -delete 2>/dev/null || true
+        find deploy/antenv -name "*.pyo" -delete 2>/dev/null || true
+        find deploy/antenv -name "*.dist-info" -type d -exec sh -c 'rm -rf "$1"/RECORD "$1"/WHEEL "$1"/top_level.txt "$1"/SOURCES.txt' _ {} \; 2>/dev/null || true
         
-        # Create Python entrypoint
-        printf '%s\n' '#!/usr/bin/env python3' 'import subprocess, sys' 'sys.exit(subprocess.call(["bash", "startup.sh"]))' > deploy/startup.py
-        chmod +x deploy/startup.py
+        # Create Python entrypoint that invokes startup.sh
+        printf '#!/usr/bin/env python3\nimport subprocess, sys\nsys.exit(subprocess.call(["bash", "startup.sh"]))\n' > deploy/startup.py
         
-        echo "✅ Package built with pre-installed venv"
         echo "Package size: $(du -sh deploy/ | cut -f1)"
-        ls -la deploy/
+
+    - name: 'Create deployment zip'
+      run: |
+        cd deploy
+        zip -r -q ../deploy.zip .
+        cd ..
+        echo "Zip size: $(du -sh deploy.zip | cut -f1)"
 
     - name: 'Azure Login'
       uses: azure/login@v2
@@ -90,17 +79,50 @@ jobs:
 
     - name: 'Deploy to Azure Web App (Production)'
       if: env.DEPLOY_ENV == 'production'
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: ${{ env.APP_NAME }}
-        package: './deploy'
-        slot-name: 'production'
-        startup-command: 'python startup.py'
+      run: |
+        az webapp deploy \
+          --name ${{ env.APP_NAME }} \
+          --resource-group PRODUCTION \
+          --src-path deploy.zip \
+          --type zip \
+          --clean true \
+          --restart true \
+          --timeout 600
+
+    - name: 'Configure startup command (Production)'
+      if: env.DEPLOY_ENV == 'production'
+      run: |
+        az webapp config set \
+          --name ${{ env.APP_NAME }} \
+          --resource-group PRODUCTION \
+          --startup-file "python startup.py"
 
     - name: 'Deploy to Azure Web App (Staging)'
       if: env.DEPLOY_ENV == 'staging'
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: ${{ env.APP_NAME }}
-        publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
-        package: './deploy'
+      run: |
+        az webapp deploy \
+          --name ${{ env.APP_NAME }} \
+          --resource-group rg-antsa-staging \
+          --src-path deploy.zip \
+          --type zip \
+          --clean true \
+          --restart true \
+          --timeout 600
+
+    - name: 'Configure startup command (Staging)'
+      if: env.DEPLOY_ENV == 'staging'
+      run: |
+        az webapp config set \
+          --name ${{ env.APP_NAME }} \
+          --resource-group rg-antsa-staging \
+          --startup-file "python startup.py"
+
+    - name: 'Verify deployment'
+      run: |
+        echo "Waiting 30s for container to start..."
+        sleep 30
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "https://${{ env.APP_NAME }}.azurewebsites.net/health" || echo "000")
+        echo "Health check HTTP code: $HTTP_CODE"
+        if [ "$HTTP_CODE" = "000" ]; then
+          echo "Service still starting up - this is expected for first deploy"
+        fi

--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -33,11 +33,17 @@ jobs:
         echo "DEPLOY_ENV=${ENV}" >> $GITHUB_ENV
         echo "APP_NAME=${APP_NAME}" >> $GITHUB_ENV
 
-    - name: 'Build deployment package with pre-built venv'
+    - name: 'Validate dependencies'
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        python -c "import fastapi; import openai; import haystack; print('All imports OK')"
+
+    - name: 'Create deployment package'
       run: |
         mkdir deploy
         
-        # Copy application source
+        # Copy application source only (no venv - built on Azure at runtime)
         cp main.py config.py personas.py session_manager.py haystack_pipeline.py \
            ui_state_manager.py tools.py requirements.txt startup.sh deploy/
         cp -r components agents document_generation utils deploy/
@@ -45,32 +51,12 @@ jobs:
         # Verify main.py is present
         test -f deploy/main.py || { echo "ERROR: main.py not found!"; exit 1; }
         
-        # Build venv with all dependencies (Ubuntu runner matches Azure Linux)
-        python -m venv deploy/antenv
-        deploy/antenv/bin/pip install --no-cache-dir -q -r requirements.txt
-        
-        # Verify key packages
-        deploy/antenv/bin/python -c "import fastapi; import openai; import haystack; print('All packages OK')"
-        
-        # Strip unnecessary files to reduce package size
-        find deploy/antenv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-        find deploy/antenv -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true
-        find deploy/antenv -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
-        find deploy/antenv -name "*.pyc" -delete 2>/dev/null || true
-        find deploy/antenv -name "*.pyo" -delete 2>/dev/null || true
-        find deploy/antenv -name "*.dist-info" -type d -exec sh -c 'rm -rf "$1"/RECORD "$1"/WHEEL "$1"/top_level.txt "$1"/SOURCES.txt' _ {} \; 2>/dev/null || true
-        
-        # Create Python entrypoint that invokes startup.sh
+        # Create Python entrypoint
         printf '#!/usr/bin/env python3\nimport subprocess, sys\nsys.exit(subprocess.call(["bash", "startup.sh"]))\n' > deploy/startup.py
         
+        echo "Package contents:"
+        ls -la deploy/
         echo "Package size: $(du -sh deploy/ | cut -f1)"
-
-    - name: 'Create deployment zip'
-      run: |
-        cd deploy
-        zip -r -q ../deploy.zip .
-        cd ..
-        echo "Zip size: $(du -sh deploy.zip | cut -f1)"
 
     - name: 'Azure Login'
       uses: azure/login@v2
@@ -79,50 +65,17 @@ jobs:
 
     - name: 'Deploy to Azure Web App (Production)'
       if: env.DEPLOY_ENV == 'production'
-      run: |
-        az webapp deploy \
-          --name ${{ env.APP_NAME }} \
-          --resource-group PRODUCTION \
-          --src-path deploy.zip \
-          --type zip \
-          --clean true \
-          --restart true \
-          --timeout 600
-
-    - name: 'Configure startup command (Production)'
-      if: env.DEPLOY_ENV == 'production'
-      run: |
-        az webapp config set \
-          --name ${{ env.APP_NAME }} \
-          --resource-group PRODUCTION \
-          --startup-file "python startup.py"
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.APP_NAME }}
+        package: './deploy'
+        slot-name: 'production'
+        startup-command: 'python startup.py'
 
     - name: 'Deploy to Azure Web App (Staging)'
       if: env.DEPLOY_ENV == 'staging'
-      run: |
-        az webapp deploy \
-          --name ${{ env.APP_NAME }} \
-          --resource-group rg-antsa-staging \
-          --src-path deploy.zip \
-          --type zip \
-          --clean true \
-          --restart true \
-          --timeout 600
-
-    - name: 'Configure startup command (Staging)'
-      if: env.DEPLOY_ENV == 'staging'
-      run: |
-        az webapp config set \
-          --name ${{ env.APP_NAME }} \
-          --resource-group rg-antsa-staging \
-          --startup-file "python startup.py"
-
-    - name: 'Verify deployment'
-      run: |
-        echo "Waiting 30s for container to start..."
-        sleep 30
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "https://${{ env.APP_NAME }}.azurewebsites.net/health" || echo "000")
-        echo "Health check HTTP code: $HTTP_CODE"
-        if [ "$HTTP_CODE" = "000" ]; then
-          echo "Service still starting up - this is expected for first deploy"
-        fi
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.APP_NAME }}
+        publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
+        package: './deploy'

--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -20,7 +20,6 @@ jobs:
 
     - name: 'Set environment variables'
       run: |
-        # Determine environment based on branch
         if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
           ENV="production"
           APP_NAME="antsa-haystack-au-production"
@@ -31,19 +30,14 @@ jobs:
           ENV="production"
           APP_NAME="antsa-haystack-au-production"
         fi
-        
         echo "DEPLOY_ENV=${ENV}" >> $GITHUB_ENV
         echo "APP_NAME=${APP_NAME}" >> $GITHUB_ENV
 
-    - name: 'Install dependencies'
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-
-    - name: 'Create deployment package'
+    - name: 'Build deployment package with pre-built venv'
       run: |
         mkdir deploy
-        # Copy full FastAPI Haystack service
+        
+        # Copy application source
         cp main.py deploy/
         cp config.py deploy/
         cp personas.py deploy/
@@ -52,33 +46,42 @@ jobs:
         cp ui_state_manager.py deploy/
         cp tools.py deploy/
         cp requirements.txt deploy/
-        cp startup.sh deploy/
-        # Copy components directory (custom Haystack components)
         cp -r components deploy/
-        # Copy new modular directories
         cp -r agents deploy/
         cp -r document_generation deploy/
         cp -r utils deploy/
         
-        # Verify main.py is present (critical for service)
+        # Verify main.py is present
         if [ ! -f deploy/main.py ]; then
-          echo "ERROR: main.py not found - Service will not work!"
+          echo "ERROR: main.py not found!"
           exit 1
         fi
         
-        # Provide a Python entrypoint that invokes our startup.sh (robust quoting)
-        printf '%s\n' '#!/usr/bin/env python3' 'import subprocess' 'subprocess.run(["bash", "startup.sh"], check=True)' > deploy/startup.py
+        # Build venv with all dependencies (runs on Ubuntu, same as Azure Linux)
+        python -m venv deploy/antenv
+        deploy/antenv/bin/pip install --no-cache-dir -r requirements.txt
+        
+        # Verify key packages installed
+        deploy/antenv/bin/python -c "import fastapi; import openai; import haystack; print('All packages OK')"
+        
+        # Create simple startup script
+        cat > deploy/startup.sh << 'STARTUP'
+        #!/bin/bash
+        cd /home/site/wwwroot
+        export HOST=${HOST:-0.0.0.0}
+        export PORT=${PORT:-8001}
+        echo "[startup] Starting Uvicorn on $HOST:$PORT"
+        exec antenv/bin/python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+        STARTUP
+        chmod +x deploy/startup.sh
+        
+        # Create Python entrypoint
+        printf '%s\n' '#!/usr/bin/env python3' 'import subprocess, sys' 'sys.exit(subprocess.call(["bash", "startup.sh"]))' > deploy/startup.py
         chmod +x deploy/startup.py
         
-        echo "✅ Full FastAPI Haystack service with WebSocket support packaged"
+        echo "✅ Package built with pre-installed venv"
+        echo "Package size: $(du -sh deploy/ | cut -f1)"
         ls -la deploy/
-
-    - name: 'Validate startup.py'
-      run: |
-        echo "--- startup.py ---"
-        sed -n '1,120p' deploy/startup.py
-        echo "---------------"
-        python -c "import ast,sys,pathlib;code=pathlib.Path('deploy/startup.py').read_text(encoding='utf-8');ast.parse(code);print('startup.py syntax OK')"
 
     - name: 'Azure Login'
       uses: azure/login@v2
@@ -93,22 +96,6 @@ jobs:
         package: './deploy'
         slot-name: 'production'
         startup-command: 'python startup.py'
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_AU }}
-        REDIS_URL: ${{ secrets.REDIS_URL_AU }}
-        DATABASE_URL: ${{ secrets.DATABASE_URL_AU }}
-        NESTJS_API_URL: 'https://au.api.antsa.ai'
-        LOG_LEVEL: 'INFO'
-        HOST: '0.0.0.0'
-        PORT: '8000'
-        SCM_DO_BUILD_DURING_DEPLOYMENT: 'true'
-        ENABLE_ORYX_BUILD: 'true'
-        SHOW_TOOL_BANNER: 'true'
-        SHOW_RAW_TOOL_JSON: 'false'
-        MAX_REQUESTS_PER_USER: '10'
-        SESSION_TIMEOUT_MINUTES: '240'
-        MAX_CONCURRENT_REQUESTS: '10000'
-        COUNTRY_CODE: 'au'
 
     - name: 'Deploy to Azure Web App (Staging)'
       if: env.DEPLOY_ENV == 'staging'

--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -1,8 +1,8 @@
-name: Deploy Haystack to Azure AU
+name: Deploy Haystack to Azure
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   workflow_dispatch:
 
 jobs:
@@ -17,6 +17,23 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+
+    - name: 'Set environment variables'
+      run: |
+        # Determine environment based on branch
+        if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+          ENV="production"
+          APP_NAME="antsa-haystack-au-production"
+        elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+          ENV="staging"
+          APP_NAME="antsa-haystack-au-staging"
+        else
+          ENV="production"
+          APP_NAME="antsa-haystack-au-production"
+        fi
+        
+        echo "DEPLOY_ENV=${ENV}" >> $GITHUB_ENV
+        echo "APP_NAME=${APP_NAME}" >> $GITHUB_ENV
 
     - name: 'Install dependencies'
       run: |
@@ -66,12 +83,13 @@ jobs:
     - name: 'Azure Login'
       uses: azure/login@v2
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS_AU }}
+        creds: ${{ env.DEPLOY_ENV == 'production' && secrets.AZURE_CREDENTIALS_AU || secrets.AZURE_CREDENTIALS_STAGING }}
 
-    - name: 'Deploy to Azure Web App'
+    - name: 'Deploy to Azure Web App (Production)'
+      if: env.DEPLOY_ENV == 'production'
       uses: azure/webapps-deploy@v2
       with:
-        app-name: 'antsa-haystack-au-production'
+        app-name: ${{ env.APP_NAME }}
         package: './deploy'
         slot-name: 'production'
         startup-command: 'python startup.py'
@@ -91,3 +109,12 @@ jobs:
         SESSION_TIMEOUT_MINUTES: '240'
         MAX_CONCURRENT_REQUESTS: '10000'
         COUNTRY_CODE: 'au'
+
+    - name: 'Deploy to Azure Web App (Staging)'
+      if: env.DEPLOY_ENV == 'staging'
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.APP_NAME }}
+        publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
+        package: './deploy'
+        startup-command: 'python startup.py'

--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -117,4 +117,3 @@ jobs:
         app-name: ${{ env.APP_NAME }}
         publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
         package: './deploy'
-        startup-command: 'python startup.py'

--- a/document_generation/end_of_treatment.py
+++ b/document_generation/end_of_treatment.py
@@ -1,0 +1,201 @@
+"""
+End-of-treatment document generation
+Generates comprehensive treatment summary letters after completing therapy
+"""
+import logging
+from typing import Dict, Any, List
+from datetime import datetime
+from openai import OpenAI
+import os
+
+logger = logging.getLogger(__name__)
+
+class EndOfTreatmentGenerator:
+    """Generates end-of-treatment summary letters from multiple therapy sessions"""
+    
+    def __init__(self):
+        self.openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    
+    async def generate_letter(
+        self,
+        client_info: Dict[str, Any],
+        practitioner_info: Dict[str, Any],
+        sessions: List[Dict[str, Any]],
+        treatment_goals: List[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Generate comprehensive end-of-treatment letter
+        
+        Args:
+            client_info: Client details (name, age, presenting issues)
+            practitioner_info: Practitioner details (name, title, registration)
+            sessions: List of session summaries with transcripts
+            treatment_goals: Initial treatment goals if available
+            
+        Returns:
+            Dictionary containing the generated letter and metadata
+        """
+        try:
+            logger.info(f"🏁 Generating end-of-treatment letter for {len(sessions)} sessions")
+            
+            # Build comprehensive prompt with all session data
+            prompt = self._build_letter_prompt(
+                client_info,
+                practitioner_info,
+                sessions,
+                treatment_goals
+            )
+            
+            # Generate letter using GPT-4
+            response = self.openai_client.chat.completions.create(
+                model="gpt-4o",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": """You are an experienced clinical psychologist writing a professional end-of-treatment summary letter.
+
+Your letter should be:
+- Professional and clinical in tone
+- Evidence-based, citing specific progress from sessions
+- Non-diagnostic (describe symptoms, not diagnoses)
+- Focused on outcomes and recommendations
+- Suitable for referring doctors or healthcare professionals
+
+Format the letter as a formal medical document."""
+                    },
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
+                ],
+                temperature=0.3,
+                max_tokens=3000,
+            )
+            
+            letter_content = response.choices[0].message.content
+            
+            logger.info(f"✅ End-of-treatment letter generated ({len(letter_content)} characters)")
+            
+            return {
+                "letter": letter_content,
+                "metadata": {
+                    "client_name": f"{client_info.get('firstName')} {client_info.get('lastName')}",
+                    "practitioner_name": f"{practitioner_info.get('firstName')} {practitioner_info.get('lastName')}",
+                    "session_count": len(sessions),
+                    "treatment_period": self._get_treatment_period(sessions),
+                    "generated_at": datetime.now().isoformat()
+                }
+            }
+            
+        except Exception as e:
+            logger.error(f"❌ Failed to generate end-of-treatment letter: {e}")
+            raise
+    
+    def _build_letter_prompt(
+        self,
+        client_info: Dict[str, Any],
+        practitioner_info: Dict[str, Any],
+        sessions: List[Dict[str, Any]],
+        treatment_goals: List[str] = None
+    ) -> str:
+        """Build the prompt for GPT-4 letter generation"""
+        
+        # Extract client details
+        client_name = f"{client_info.get('firstName')} {client_info.get('lastName')}"
+        client_age = client_info.get('age', 'N/A')
+        client_gender = client_info.get('gender', 'N/A')
+        
+        # Extract practitioner details
+        practitioner_name = f"{practitioner_info.get('firstName')} {practitioner_info.get('lastName')}"
+        practitioner_title = practitioner_info.get('title', 'Clinical Psychologist')
+        
+        # Get treatment period
+        treatment_period = self._get_treatment_period(sessions)
+        
+        # Summarize sessions
+        session_summaries = self._summarize_sessions(sessions)
+        
+        # Build goals section
+        goals_section = ""
+        if treatment_goals:
+            goals_section = f"""
+INITIAL TREATMENT GOALS:
+{chr(10).join([f"- {goal}" for goal in treatment_goals])}
+"""
+        
+        return f"""Generate a comprehensive end-of-treatment summary letter with the following information:
+
+CLIENT INFORMATION:
+- Name: {client_name}
+- Age: {client_age}
+- Gender: {client_gender}
+
+PRACTITIONER INFORMATION:
+- Name: {practitioner_name}
+- Title: {practitioner_title}
+
+TREATMENT PERIOD:
+- First Session: {treatment_period['start']}
+- Last Session: {treatment_period['end']}
+- Total Sessions: {len(sessions)}
+
+{goals_section}
+
+SESSION SUMMARIES:
+{session_summaries}
+
+Please generate a professional end-of-treatment letter that includes:
+
+1. **Treatment Summary**: Overview of the treatment period and number of sessions
+2. **Initial Presentation**: Client's presenting concerns at the start of treatment
+3. **Treatment Approach**: Therapeutic modalities used (CBT, ACT, mindfulness, etc.)
+4. **Progress and Outcomes**: 
+   - Specific improvements observed across sessions
+   - Skills developed and strategies learned
+   - Behavioral and emotional changes
+5. **Goals Achieved**: Assessment of progress toward initial goals
+6. **Recommendations for Ongoing Care**: 
+   - Maintenance strategies
+   - Potential need for future support
+   - Self-care practices to continue
+7. **Discharge Summary**: Final clinical impression and date of discharge
+
+Format the letter as a formal clinical document addressed to "To Whom It May Concern" or the referring physician."""
+
+    def _summarize_sessions(self, sessions: List[Dict[str, Any]]) -> str:
+        """Create a concise summary of all sessions for the prompt"""
+        summaries = []
+        
+        for i, session in enumerate(sessions, 1):
+            date = session.get('scheduledStartTime', 'Unknown date')
+            summary = session.get('summary', '')
+            key_themes = session.get('themes', [])
+            
+            session_summary = f"""
+Session {i} ({date}):
+Key Themes: {', '.join(key_themes) if key_themes else 'N/A'}
+Summary: {summary[:500] if summary else 'No summary available'}
+"""
+            summaries.append(session_summary)
+        
+        return "\n".join(summaries)
+    
+    def _get_treatment_period(self, sessions: List[Dict[str, Any]]) -> Dict[str, str]:
+        """Extract start and end dates from sessions"""
+        if not sessions:
+            return {"start": "N/A", "end": "N/A"}
+        
+        dates = [s.get('scheduledStartTime') for s in sessions if s.get('scheduledStartTime')]
+        
+        if not dates:
+            return {"start": "N/A", "end": "N/A"}
+        
+        sorted_dates = sorted(dates)
+        
+        return {
+            "start": sorted_dates[0],
+            "end": sorted_dates[-1]
+        }
+
+# Global instance
+end_of_treatment_generator = EndOfTreatmentGenerator()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,6 @@ pgvector>=0.2.5
 # General utilities
 python-multipart==0.0.12
 httpx==0.27.0
+aiohttp>=3.9.5
 
 haystack-ai==2.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ pydantic==2.10.3
 pydantic-settings==2.6.1
 
 # AI/ML dependencies - Direct OpenAI (compatible with haystack-ai 2.17.1)
-openai>=1.106.1
+# Pin to v1.x - OpenAI SDK v2 has breaking changes that crash the service
+openai>=1.106.1,<2.0.0
 
 # Auth / JWT
 PyJWT==2.10.1

--- a/startup.sh
+++ b/startup.sh
@@ -4,19 +4,20 @@ set -euo pipefail
 cd /home/site/wwwroot
 export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
-PACKAGES=/tmp/pypackages
 
-# Install packages to /tmp (fast local SSD, not slow Azure Files)
-# This is rebuilt on each container start but takes only ~60s on local disk
-if python -c "import sys; sys.path.insert(0,'$PACKAGES'); import fastapi, openai, haystack" 2>/dev/null; then
-  echo "[startup] Packages already installed"
+VENV=/tmp/venv
+
+# Use /tmp (local SSD) for the venv - much faster than Azure Files
+# The venv is rebuilt on each container start but takes ~5 min on local disk
+if [ -d "$VENV" ] && "$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp" 2>/dev/null; then
+  echo "[startup] Packages OK - starting immediately"
 else
-  echo "[startup] Installing packages to $PACKAGES..."
-  pip install --no-cache-dir --target "$PACKAGES" -r requirements.txt -q
+  echo "[startup] Building venv at $VENV (local SSD)..."
+  rm -rf "$VENV"
+  python -m venv "$VENV"
+  "$VENV/bin/pip" install --no-cache-dir -r requirements.txt
   echo "[startup] Done installing packages"
 fi
 
-export PYTHONPATH="$PACKAGES:${PYTHONPATH:-}"
-
 echo "[startup] Launching Uvicorn on $HOST:$PORT"
-exec python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -28,7 +28,8 @@ rm -rf "$VENV"
 echo "[startup] Done installing packages"
 
 # Verify critical imports
-"$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp, httpx, pydantic; print('[startup] All imports verified OK')"
+"$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp, httpx, pydantic"
+echo "[startup] All imports verified OK"
 
 echo "[startup] Launching Uvicorn on $HOST:$PORT"
 exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -13,12 +13,14 @@ if [ ! -d "$VENV_DIR" ]; then
   python -m venv "$VENV_DIR"
 fi
 
-echo "[startup] Upgrading pip..."
-"$VENV_DIR/bin/python" -m pip install --upgrade pip >/dev/null
-
-if [ -f requirements.txt ]; then
-  echo "[startup] Installing requirements..."
+# Only install requirements if key packages are missing.
+# Oryx already installs them during deployment - avoid duplicate pip install
+# which can cause the startup probe to timeout (230s).
+if ! "$VENV_DIR/bin/python" -c "import fastapi; import openai; import haystack" 2>/dev/null; then
+  echo "[startup] Key packages missing, installing requirements..."
   "$VENV_DIR/bin/pip" install --no-cache-dir -r requirements.txt
+else
+  echo "[startup] Packages already installed by Oryx, skipping pip install"
 fi
 
 echo "[startup] Launching Uvicorn on $HOST:$PORT"

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+set -euo pipefail
+
 cd /home/site/wwwroot
 export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
-echo "[startup] Starting Uvicorn on $HOST:$PORT"
+
+echo "[startup] Starting Haystack service"
+echo "[startup] Python: $(antenv/bin/python --version 2>&1)"
+echo "[startup] Launching Uvicorn on $HOST:$PORT"
+
 exec antenv/bin/python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -5,8 +5,19 @@ cd /home/site/wwwroot
 export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
 
-echo "[startup] Starting Haystack service"
-echo "[startup] Python: $(antenv/bin/python --version 2>&1)"
-echo "[startup] Launching Uvicorn on $HOST:$PORT"
+VENV=antenv
 
-exec antenv/bin/python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+# Fast path: venv exists and works -> start immediately
+if [ -d "$VENV" ] && "$VENV/bin/python" -c "import fastapi, openai, haystack" 2>/dev/null; then
+  echo "[startup] Packages OK - starting immediately"
+  exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+fi
+
+# First-time or recovery: build fresh venv
+echo "[startup] Building virtual environment (first-time setup)..."
+rm -rf "$VENV"
+python -m venv "$VENV"
+"$VENV/bin/pip" install --no-cache-dir -r requirements.txt
+echo "[startup] Venv built successfully"
+
+exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -4,20 +4,19 @@ set -euo pipefail
 cd /home/site/wwwroot
 export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
+PACKAGES=/tmp/pypackages
 
-VENV=antenv
-
-# Fast path: venv exists and works -> start immediately
-if [ -d "$VENV" ] && "$VENV/bin/python" -c "import fastapi, openai, haystack" 2>/dev/null; then
-  echo "[startup] Packages OK - starting immediately"
-  exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+# Install packages to /tmp (fast local SSD, not slow Azure Files)
+# This is rebuilt on each container start but takes only ~60s on local disk
+if python -c "import sys; sys.path.insert(0,'$PACKAGES'); import fastapi, openai, haystack" 2>/dev/null; then
+  echo "[startup] Packages already installed"
+else
+  echo "[startup] Installing packages to $PACKAGES..."
+  pip install --no-cache-dir --target "$PACKAGES" -r requirements.txt -q
+  echo "[startup] Done installing packages"
 fi
 
-# First-time or recovery: build fresh venv
-echo "[startup] Building virtual environment (first-time setup)..."
-rm -rf "$VENV"
-python -m venv "$VENV"
-"$VENV/bin/pip" install --no-cache-dir -r requirements.txt
-echo "[startup] Venv built successfully"
+export PYTHONPATH="$PACKAGES:${PYTHONPATH:-}"
 
-exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+echo "[startup] Launching Uvicorn on $HOST:$PORT"
+exec python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -6,22 +6,18 @@ export PORT=${PORT:-8001}
 export VENV_DIR=${VENV_DIR:-"$PWD/antenv"}
 
 echo "[startup] Using Python: $(python --version 2>/dev/null || echo 'not found')"
-echo "[startup] Ensuring virtualenv at: $VENV_DIR"
+echo "[startup] Virtual env at: $VENV_DIR"
 
-if [ ! -d "$VENV_DIR" ]; then
-  echo "[startup] Creating virtual environment..."
-  python -m venv "$VENV_DIR"
-fi
-
-# Only install requirements if key packages are missing.
-# Oryx already installs them during deployment - avoid duplicate pip install
-# which can cause the startup probe to timeout (230s).
-if ! "$VENV_DIR/bin/python" -c "import fastapi; import openai; import haystack" 2>/dev/null; then
-  echo "[startup] Key packages missing, installing requirements..."
-  "$VENV_DIR/bin/pip" install --no-cache-dir -r requirements.txt
+# Oryx installs packages during deployment (SCM_DO_BUILD_DURING_DEPLOYMENT=true).
+# Do NOT run pip install at runtime - it takes too long and causes startup probe timeouts.
+# If the venv doesn't exist, Oryx didn't build properly - fall back to system python.
+if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/python" ]; then
+  echo "[startup] Using Oryx-built virtual environment"
+  PYTHON="$VENV_DIR/bin/python"
 else
-  echo "[startup] Packages already installed by Oryx, skipping pip install"
+  echo "[startup] WARNING: No virtual environment found, using system Python"
+  PYTHON="python"
 fi
 
 echo "[startup] Launching Uvicorn on $HOST:$PORT"
-exec "$VENV_DIR/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+exec $PYTHON -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -1,24 +1,6 @@
 #!/bin/bash
-set -euo pipefail
-
+cd /home/site/wwwroot
 export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
-export VENV_DIR=${VENV_DIR:-"$PWD/antenv"}
-
-echo "[startup] Using Python: $(python --version 2>/dev/null || echo 'not found')"
-echo "[startup] Virtual env at: $VENV_DIR"
-
-# Fast path: venv exists and packages are importable → start immediately
-if [ -d "$VENV_DIR" ] && "$VENV_DIR/bin/python" -c "import fastapi; import openai; import haystack" 2>/dev/null; then
-  echo "[startup] Packages OK, starting Uvicorn"
-  exec "$VENV_DIR/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
-fi
-
-# Recovery path: venv missing or corrupt → nuke and rebuild
-echo "[startup] Venv missing or corrupt, rebuilding..."
-rm -rf "$VENV_DIR"
-python -m venv "$VENV_DIR"
-"$VENV_DIR/bin/pip" install --no-cache-dir -r requirements.txt
-
-echo "[startup] Launching Uvicorn on $HOST:$PORT"
-exec "$VENV_DIR/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+echo "[startup] Starting Uvicorn on $HOST:$PORT"
+exec antenv/bin/python -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -6,21 +6,29 @@ export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
 
 VENV=/tmp/venv
+PYTHON=/opt/python/3.11.14/bin/python
 
-# CRITICAL: Oryx injects corrupt antenv into PYTHONPATH. Clear it so pip
-# doesn't skip packages it thinks are already installed from the broken antenv.
+# CRITICAL: Oryx injects corrupt antenv into PYTHONPATH. Nuke it entirely.
 unset PYTHONPATH
+export PYTHONPATH=""
 
-# Use /tmp (local SSD) for the venv - much faster than Azure Files
-if [ -d "$VENV" ] && "$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp" 2>/dev/null; then
+# Fast path: venv already built with all packages
+if [ -d "$VENV" ] && "$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp, httpx, pydantic" 2>/dev/null; then
   echo "[startup] Packages OK - starting immediately"
-else
-  echo "[startup] Building venv at $VENV (local SSD)..."
-  rm -rf "$VENV"
-  python -m venv "$VENV"
-  "$VENV/bin/pip" install --no-cache-dir -r requirements.txt
-  echo "[startup] Done installing packages"
+  exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
 fi
+
+# Build fresh venv using absolute Python path (not Oryx-modified PATH)
+echo "[startup] Building venv at $VENV..."
+rm -rf "$VENV"
+"$PYTHON" -m venv "$VENV"
+
+# Force reinstall everything - ignore any packages Oryx/antenv put in the path
+"$VENV/bin/pip" install --no-cache-dir --ignore-installed -r requirements.txt
+echo "[startup] Done installing packages"
+
+# Verify critical imports
+"$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp, httpx, pydantic; print('[startup] All imports verified OK')"
 
 echo "[startup] Launching Uvicorn on $HOST:$PORT"
 exec "$VENV/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/startup.sh
+++ b/startup.sh
@@ -7,8 +7,11 @@ export PORT=${PORT:-8001}
 
 VENV=/tmp/venv
 
+# CRITICAL: Oryx injects corrupt antenv into PYTHONPATH. Clear it so pip
+# doesn't skip packages it thinks are already installed from the broken antenv.
+unset PYTHONPATH
+
 # Use /tmp (local SSD) for the venv - much faster than Azure Files
-# The venv is rebuilt on each container start but takes ~5 min on local disk
 if [ -d "$VENV" ] && "$VENV/bin/python" -c "import fastapi, openai, haystack, aiohttp" 2>/dev/null; then
   echo "[startup] Packages OK - starting immediately"
 else

--- a/startup.sh
+++ b/startup.sh
@@ -8,16 +8,17 @@ export VENV_DIR=${VENV_DIR:-"$PWD/antenv"}
 echo "[startup] Using Python: $(python --version 2>/dev/null || echo 'not found')"
 echo "[startup] Virtual env at: $VENV_DIR"
 
-# Oryx installs packages during deployment (SCM_DO_BUILD_DURING_DEPLOYMENT=true).
-# Do NOT run pip install at runtime - it takes too long and causes startup probe timeouts.
-# If the venv doesn't exist, Oryx didn't build properly - fall back to system python.
-if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/python" ]; then
-  echo "[startup] Using Oryx-built virtual environment"
-  PYTHON="$VENV_DIR/bin/python"
-else
-  echo "[startup] WARNING: No virtual environment found, using system Python"
-  PYTHON="python"
+# Fast path: venv exists and packages are importable → start immediately
+if [ -d "$VENV_DIR" ] && "$VENV_DIR/bin/python" -c "import fastapi; import openai; import haystack" 2>/dev/null; then
+  echo "[startup] Packages OK, starting Uvicorn"
+  exec "$VENV_DIR/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
 fi
 
+# Recovery path: venv missing or corrupt → nuke and rebuild
+echo "[startup] Venv missing or corrupt, rebuilding..."
+rm -rf "$VENV_DIR"
+python -m venv "$VENV_DIR"
+"$VENV_DIR/bin/pip" install --no-cache-dir -r requirements.txt
+
 echo "[startup] Launching Uvicorn on $HOST:$PORT"
-exec $PYTHON -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info
+exec "$VENV_DIR/bin/python" -m uvicorn main:app --host "$HOST" --port "$PORT" --log-level info

--- a/tools.py
+++ b/tools.py
@@ -2405,22 +2405,47 @@ PERSONALIZATION INSTRUCTIONS:
             # Get UI state from the UI state manager
             from ui_state_manager import ui_state_manager
             
-            # Use SYNC methods to avoid event loop conflicts
-            all_sessions_summary = ui_state_manager.get_all_sessions_summary_sync()
-            
-            if not all_sessions_summary:
-                return {
-                    "generated_documents": [],
-                    "document_count": 0,
-                    "message": "No active UI session found. Document access requires an active browser session.",
-                    "status": "no_active_session"
-                }
-            
-            # Get the most recent session's UI state
-            latest_session_id = max(all_sessions_summary.keys(), 
-                                  key=lambda k: all_sessions_summary[k].get('last_updated', ''))
-            
-            all_documents = ui_state_manager.get_generated_documents_sync(latest_session_id)
+            # Strategy: check the current session first (most reliable — avoids race conditions
+            # where a newly-created session hasn't had its state pushed yet), then fall back
+            # to aggregating documents from ALL sessions.  This is safer than picking only the
+            # "most recently updated" session, which may be a stale empty session.
+            current_session_id = getattr(self, 'session_id', None)
+
+            all_documents: list = []
+
+            if current_session_id:
+                all_documents = ui_state_manager.get_generated_documents_sync(current_session_id)
+                logger.info(f"📋 Current session {current_session_id}: {len(all_documents)} document entries")
+
+            # If current session has no documents, aggregate from ALL sessions
+            has_current_docs = any(d.get("isGenerated") == True for d in all_documents)
+            if not has_current_docs:
+                all_sessions_summary = ui_state_manager.get_all_sessions_summary_sync()
+                logger.info(f"🔍 Checking all {len(all_sessions_summary)} sessions for documents")
+
+                # Collect documents from every session, deduplicating by documentId
+                seen_ids: set = set()
+                aggregated: list = []
+                for sid in all_sessions_summary.keys():
+                    if sid == current_session_id:
+                        continue  # Already checked
+                    docs = ui_state_manager.get_generated_documents_sync(sid)
+                    for doc in docs:
+                        doc_id = doc.get("documentId", "")
+                        if doc_id and doc_id not in seen_ids:
+                            seen_ids.add(doc_id)
+                            aggregated.append(doc)
+
+                if aggregated:
+                    logger.info(f"📂 Found {len(aggregated)} documents across other sessions")
+                    all_documents = aggregated
+                elif not all_sessions_summary:
+                    return {
+                        "generated_documents": [],
+                        "document_count": 0,
+                        "message": "No active UI session found. Document access requires an active browser session.",
+                        "status": "no_active_session"
+                    }
             
             # Filter to only include ACTUAL generated documents (isGenerated=True)
             # Loaded sessions have isGenerated=False and should NOT be listed here


### PR DESCRIPTION
## Summary
- `_get_generated_documents` now checks `self.session_id` (the current Haystack chat session) first instead of blindly picking the most-recently-updated Redis session
- If the current session has no generated documents, aggregates from ALL sessions (deduplicating by documentId) rather than stopping at a single session
- Eliminates the race condition where a new session had not yet received its UI state push at the time the tool ran, causing the AI to report '0 documents found'

## Test plan
- [ ] Generate a document, open the AI assistant and immediately ask it to edit the doc — should find it
- [ ] Close sidebar, generate a doc, reopen sidebar and ask to edit — should find it
- [ ] Multiple sessions open: tool should aggregate and return all docs