### PR TITLE
fix: document refinement instructions ignored

### DIFF
--- a/document_generation/generator.py
+++ b/document_generation/generator.py
@@ -180,7 +180,7 @@ Always personalize the document by using the actual client and practitioner name
             system_prompt += f"\n\nADDITIONAL CONTEXT AND INSTRUCTIONS FROM PRACTITIONER:\n{generation_instructions}\n\nIMPORTANT: This additional context should be integrated into your understanding of the transcript and used to correct any assumptions or add missing background information. Regenerate the document incorporating this new information.\n"
         
         # Check if this is a modification/regeneration request
-        is_regeneration = template_content.startswith("CRITICAL MODIFICATION REQUEST")
+        is_regeneration = template_content.startswith("CRITICAL INSTRUCTIONS FOR AI ASSISTANT:")
         
         # Build source content section (transcript and/or notes)
         source_content = ""


### PR DESCRIPTION
## Summary
- Fixed regeneration detection in `generator.py` — was checking for wrong prefix string
- Refinement requests (e.g. "use first names only") were falling through to the normal generation path, which overrides user instructions with "use full names throughout"

## Root cause
`tools.py` constructs refinement templates starting with `"CRITICAL INSTRUCTIONS FOR AI ASSISTANT:"` but `generator.py` checked for `"CRITICAL MODIFICATION REQUEST"` — so `is_regeneration` was always `False`.

## Test plan
- [ ] Ask AI to regenerate a document with "first names only" — verify output uses first names