### PR TITLE
ci: add e2e gate caller workflow

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,0 +1,17 @@
+name: e2e
+
+# Thin caller — defers to the reusable workflow in antsa-pty-ltd/infra.
+# Runs the full Playwright suite against an ephemeral docker-compose
+# stack. Required check on PRs into develop (set in branch protection).
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  e2e:
+    uses: antsa-pty-ltd/infra/.github/workflows/e2e.yml@develop
+    with:
+      triggering_repo: ${{ github.event.repository.name }}
+      triggering_ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit


### PR DESCRIPTION
## What

Adds the `e2e` gate workflow. Every PR into `develop` will trigger the full
Playwright suite running against an ephemeral copy of the docker-compose
stack on a GitHub-hosted runner (~7-12 min per run).

The actual workflow lives in `antsa-pty-ltd/infra/.github/workflows/e2e.yml`
(reusable). This PR just adds the thin caller.

## Prereqs before this can go green

1. `antsa-pty-ltd/infra` repo exists ✅
2. GitHub App `Antsa CI` created with read access to all 5 repos
3. Org-level Actions secrets:
   - `ANTSA_CI_APP_ID`, `ANTSA_CI_APP_PRIVATE_KEY`
   - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK`
   - `OPEN_AI_API_KEY`
   - `ASSEMBLYAI_API_KEY`

## After merge

Branch protection on `develop` should be updated to require the `e2e` check
before merge.