### PR TITLE
fix(security): update AI prompts for PII token-based pseudonymization

### DIFF
--- a/document_generation/generator.py
+++ b/document_generation/generator.py
@@ -54,7 +54,7 @@ async def generate_document_from_context(
         
         # Log detailed segment information for debugging
         unique_transcript_ids = set(seg.get('transcript_id', seg.get('transcriptId', 'unknown')) for seg in segments)
-        logger.info(f"🎨 Generating document: {len(segments)} segments from {len(unique_transcript_ids)} sessions, Client: '{client_name}', Practitioner: '{practitioner_name}'")
+        logger.info(f"🎨 Generating document: {len(segments)} segments from {len(unique_transcript_ids)} sessions, Client ID: '{client_info.get('id', 'unknown')}'")
         
         # Sort segments deterministically for consistent ordering
         # Sort by: transcript_id, start_time to ensure consistent document generation
@@ -159,20 +159,17 @@ THERAPEUTIC INTERVENTION FOCUS - CRITICAL:
 - If the practitioner mentioned specific techniques or strategies, include those exact terms
 - Document any homework or between-session tasks exactly as assigned
 
-PERSONALIZATION REQUIREMENTS - ABSOLUTELY CRITICAL:
-- This is the MOST IMPORTANT requirement: You MUST use the specific names provided
-- NEVER EVER use generic terms like "Client", "the client", "client", "the patient", "patient", "the individual", "the counselor", "the therapist", or "the practitioner"
-- The CLIENT INFORMATION section contains the client's actual name - use it every single time
-- The PRACTITIONER INFORMATION section contains the practitioner's actual name - use it every single time
-- Every reference to the client or practitioner MUST use their specific names
-- This requirement overrides all other instructions - names are mandatory
-- Double-check every sentence to ensure you used the correct names
+PERSONALIZATION REQUIREMENTS:
+- Use the client and practitioner identifiers EXACTLY as provided (e.g., [CLIENT_NAME], [PRACTITIONER_NAME])
+- These are privacy-safe placeholder tokens that will be replaced with real names in post-processing
+- Use them consistently wherever you would reference the client or practitioner
+- Do NOT replace these tokens with generic terms like "the client" or "the therapist"
+- Do NOT invent or guess real names — always use the exact identifiers provided
 
 You are an AI assistant helping to generate clinical documentation from therapy session transcripts.
 Use the provided template to structure the document, but fill it with information from the transcript.
 Be professional, accurate, and only include information that was actually discussed in the session.
 Focus particularly on preserving the integrity of therapeutic interventions and strategies as they were actually delivered.
-Always personalize the document by using the actual client and practitioner names provided.
 """
         
         # Add generation instructions if provided
@@ -232,7 +229,7 @@ Always personalize the document by using the actual client and practitioner name
 {source_content}
 
 **Key Requirements:**
-- Use {client_name} and {practitioner_name} throughout (never "the client" or "the therapist")
+- Use {client_name} and {practitioner_name} identifiers exactly as provided throughout the document
 - Replace template placeholders (like {{{{date}}}}, {{{{practitionerName}}}}) with actual values
 - Be thorough and detailed - aim for 800-1500+ words with full paragraphs
 - Document everything discussed with specific examples and quotes

--- a/main.py
+++ b/main.py
@@ -277,12 +277,12 @@ def get_enhanced_system_prompt(persona_type: str, ui_state: Dict[str, Any] = Non
         context_parts = []
         context_parts.append(f"Page: {page_url}")
         
-        # IMPORTANT: Only show client info if both name AND id are present (indicates active selection)
-        # Do NOT inject client_id alone as it may be stale from previous sessions
+        # IMPORTANT: Use tokenized client reference — do NOT send real names to AI
+        # The client_name from UI state may contain real PII; use a token instead
         if client_name and client_id:
-            context_parts.append(f"Client: {client_name} ({client_id})")
+            context_parts.append(f"Client: [CLIENT_NAME] ({client_id})")
         elif client_name:
-            context_parts.append(f"Client: {client_name} (use search_clients to get ID)")
+            context_parts.append(f"Client: [CLIENT_NAME] (use search_clients to get ID)")
         else:
             context_parts.append(f"Client: None (use search_clients if needed)")
         
@@ -957,7 +957,7 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
             if not message.strip():
                 continue
                 
-            logger.info(f"Processing message for session {session_id}: {message[:50]}...")
+            logger.info(f"Processing message for session {session_id}: {len(message)} chars")
             
             await websocket.send_text(json.dumps({
                 "type": "typing",

--- a/pii_utils.py
+++ b/pii_utils.py
@@ -1,0 +1,86 @@
+"""
+PII Utilities for the Haystack service.
+
+Since the NestJS backend now sends tokenized data (with [CLIENT_NAME], [PRACTITIONER_NAME]
+placeholders), the Haystack service primarily needs:
+1. Log sanitization — ensure PII never appears in log output
+2. Defensive tokenization — catch any PII that slipped through
+"""
+
+import re
+import logging
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def sanitize_for_logging(text: str, sensitive_values: Optional[List[str]] = None) -> str:
+    """
+    Remove or mask PII from text before logging.
+
+    Args:
+        text: The text to sanitize
+        sensitive_values: Optional list of known sensitive values to mask
+
+    Returns:
+        Sanitized text safe for logging
+    """
+    if not text:
+        return text
+
+    sanitized = text
+
+    # Mask any explicitly provided sensitive values
+    if sensitive_values:
+        for value in sensitive_values:
+            if value and len(value) > 1:
+                sanitized = sanitized.replace(value, "[REDACTED]")
+
+    return sanitized
+
+
+def sanitize_dict_for_logging(data: dict, sensitive_keys: Optional[List[str]] = None) -> dict:
+    """
+    Create a log-safe copy of a dictionary by redacting sensitive keys.
+
+    Args:
+        data: Dictionary to sanitize
+        sensitive_keys: Keys whose values should be redacted.
+                       Defaults to common PII field names.
+
+    Returns:
+        New dictionary with sensitive values redacted
+    """
+    if not data:
+        return data
+
+    if sensitive_keys is None:
+        sensitive_keys = [
+            "name", "firstName", "lastName", "first_name", "last_name",
+            "email", "phone", "address", "dob", "date_of_birth",
+            "occupation", "provider_number", "providerNumber",
+        ]
+
+    result = {}
+    for key, value in data.items():
+        if key.lower() in [k.lower() for k in sensitive_keys]:
+            result[key] = "[REDACTED]"
+        elif isinstance(value, dict):
+            result[key] = sanitize_dict_for_logging(value, sensitive_keys)
+        elif isinstance(value, list) and len(value) > 0 and isinstance(value[0], dict):
+            result[key] = [sanitize_dict_for_logging(item, sensitive_keys) if isinstance(item, dict) else item for item in value]
+        else:
+            result[key] = value
+
+    return result
+
+
+def is_tokenized(text: str) -> bool:
+    """
+    Check if text contains PII tokens (indicating it's already been tokenized).
+
+    Returns True if the text contains patterns like [CLIENT_NAME], [PRACTITIONER_NAME], etc.
+    """
+    if not text:
+        return False
+    return bool(re.search(r'\[[A-Z_]+(?:_\d+)?\]', text))

--- a/tools.py
+++ b/tools.py
@@ -2156,25 +2156,22 @@ class ToolManager:
 - Always defer diagnosis to qualified medical professionals
 
 PERSONALIZATION INSTRUCTIONS:
-- When referring to the person in this session, use their actual name from the session content instead of generic terms
-- Replace "the client", "client", "the patient", "patient", or "the individual" with their actual name
-- Use their full name for formal references and first name for casual mentions
-- Make the document feel personalized and human-centered by using their actual name throughout
+- Use the client and practitioner identifiers exactly as provided (e.g., [CLIENT_NAME], [PRACTITIONER_NAME])
+- These are privacy-safe placeholder tokens that will be replaced with real names in post-processing
+- Use them consistently wherever you would reference the client or practitioner
+- Do NOT replace these tokens with generic terms or invent real names
 
 """
             
             if generation_instructions and isinstance(generation_instructions, str) and generation_instructions.strip():
-                logger.info(f"🎨 [DEBUG] _generate_document_from_loaded received generation_instructions: '{generation_instructions.strip()}'")
                 user_guidance_header = (
                     "ADDITIONAL INSTRUCTIONS: Apply the following user-provided guidance throughout the document generation. Use the existing template structure; keep mandatory clinical sections. If style guidance conflicts with clinical clarity, prefer clarity while reflecting style.\n\n"
                     "User Guidance (verbatim):\n" + generation_instructions.strip() + "\n\n"
                 )
                 footer = "\n\n---\nApplied Style Notes: Briefly summarize how the above guidance was applied."
                 effective_template_content = anti_diagnosis_header + user_guidance_header + template_content + footer
-                logger.info(f"🎨 [DEBUG] Template content modified with instructions (length: {len(effective_template_content)} chars)")
             else:
                 effective_template_content = anti_diagnosis_header + template_content
-                logger.info(f"🎨 [DEBUG] _generate_document_from_loaded NO generation_instructions provided: {generation_instructions}")
 
             action_payload = {
                 "templateContent": effective_template_content,
@@ -3638,7 +3635,7 @@ Please refine the following document according to these instructions:
                              date_to: str = None, keywords: str = None, limit: int = 10) -> Dict[str, Any]:
         """Search for transcription sessions"""
         try:
-            logger.info(f"🔍 search_sessions called with: client_name={client_name}, client_id={client_id}, keywords={keywords}")
+            logger.info(f"🔍 search_sessions called with: client_id={client_id}, keywords={keywords}")
             
             params = {'limit': str(limit)}
             
@@ -3796,7 +3793,7 @@ Please refine the following document according to these instructions:
     async def _set_client_selection(self, client_name: str, client_id: str, page_context: dict = None) -> Dict[str, Any]:
         """Set the client selection in the UI (like selecting from AutoComplete)"""
         try:
-            logger.info(f"👤 set_client_selection called with: client_name={client_name}, client_id={client_id}")
+            logger.info(f"👤 set_client_selection called with: client_id={client_id}")
             
             if not client_name or not client_id:
                 return {
@@ -3856,7 +3853,7 @@ Please refine the following document according to these instructions:
     async def _load_session_direct(self, session_id: str, client_id: str, client_name: str, recording_date: str, duration: float, total_segments: int, average_confidence: float, page_context: dict = None) -> Dict[str, Any]:
         """Load a session directly using existing UI logic (like clicking Load Session button)"""
         try:
-            logger.info(f"📂 load_session_direct called with: session_id={session_id}, client_name={client_name}")
+            logger.info(f"📂 load_session_direct called with: session_id={session_id}")
             
             if not session_id or not client_id or not client_name:
                 return {


### PR DESCRIPTION
## Summary
- Rewrite `generator.py` system prompt: replace "NEVER use generic terms" mandate with token-aware instructions that work with `[CLIENT_NAME]`/`[PRACTITIONER_NAME]` placeholders from the NestJS backend
- Update `tools.py` personalization instructions to use token placeholders instead of mandating real names
- Tokenize `client_name` from UI state in `main.py` before injecting into AI system prompts
- Sanitize logging: remove client/practitioner names from all log statements, remove verbose `[DEBUG]` logs
- Add `pii_utils.py` utility for defensive log sanitization

## Context
The NestJS API backend (`antsa-pty-ltd/api#149`) now sends tokenized data to this service. These changes ensure the Haystack service correctly handles tokens and doesn't re-introduce real PII into AI prompts or logs.

## Test plan
- [ ] Verify document generation produces correct output with tokenized input
- [ ] Verify WebSocket chat uses `[CLIENT_NAME]` in system prompts instead of real names
- [ ] Verify no client names appear in Haystack service logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)