### PR TITLE
ci: post Teams alert on develop deploy failure

### DIFF
--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -79,3 +79,10 @@ jobs:
         app-name: ${{ env.APP_NAME }}
         publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
         package: './deploy'
+
+    - name: 'Notify Teams on develop failure'
+      if: failure() && github.ref == 'refs/heads/develop'
+      uses: antsa-pty-ltd/infra/.github/actions/teams-notify@develop
+      with:
+        webhook-url: ${{ secrets.TEAMS_WEBHOOK }}
+        title: 'Haystack deploy failed'


### PR DESCRIPTION
## Summary
Adds a final step to `deploy-api-country.yml` that calls the `antsa-pty-ltd/infra/.github/actions/teams-notify` composite action when the deploy job fails on the develop branch.

## Why
When `develop` deploys break, today nobody notices until someone tries to use staging. This surfaces failures in the Technology Teams channel within seconds.

## Behaviour
- `if: failure() && github.ref == 'refs/heads/develop'` — only fires on develop failures, not master.
- The composite action no-ops when `TEAMS_WEBHOOK` secret is empty, so this can land before the webhook URL exists.

## Action required after merge
1. In Teams → Technology channel → "..." → Workflows → "Post to a channel when a webhook request is received". Save the URL.
2. Add as a repo secret named `TEAMS_WEBHOOK` to api (and web/admin/haystack — separate PRs will repeat this for each).

Part of Sprint 1 testing-foundation work — see `infra/docs/testing-journal.md`.

Generated with [Claude Code](https://claude.com/claude-code)
