### PR TITLE
ci: add pre-merge test workflow

### DIFF
--- a/.github/workflows/test-haystack.yml
+++ b/.github/workflows/test-haystack.yml
@@ -1,0 +1,43 @@
+name: Haystack - Test
+
+# Pre-merge gate for haystack-service. Validates imports + runs pytest if
+# tests exist. Lightweight by design — full e2e validation happens via the
+# infra/ staging-smoke workflow after deploy.
+
+on:
+  pull_request:
+    branches: [develop, master, main]
+  push:
+    branches: [develop]
+
+jobs:
+  test:
+    name: Lint + Imports + Pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate imports
+        run: |
+          python -c "import main; import haystack_pipeline; import tools; import personas; print('imports OK')"
+
+      - name: Run pytest if any tests exist
+        run: |
+          if find . -name 'test_*.py' -not -path './venv/*' -not -path './.venv/*' | head -1 | grep -q .; then
+            pip install pytest
+            pytest -x -q
+          else
+            echo "No test_*.py files found — skipping pytest. Smoke coverage runs post-deploy."
+          fi

--- a/.github/workflows/test-haystack.yml
+++ b/.github/workflows/test-haystack.yml
@@ -33,11 +33,14 @@ jobs:
         run: |
           python -c "import main; import haystack_pipeline; import tools; import personas; print('imports OK')"
 
-      - name: Run pytest if any tests exist
+      - name: Run pytest if any unit tests exist
         run: |
-          if find . -name 'test_*.py' -not -path './venv/*' -not -path './.venv/*' | head -1 | grep -q .; then
+          # Look for pytest unit tests under tests/ only. The repo's
+          # top-level test_integration.py is a manual smoke script that
+          # needs a running server + auth token — not a pre-merge gate.
+          if [ -d tests ] && find tests -name 'test_*.py' | head -1 | grep -q .; then
             pip install pytest
-            pytest -x -q
+            pytest tests -x -q
           else
-            echo "No test_*.py files found — skipping pytest. Smoke coverage runs post-deploy."
+            echo "No tests/ directory with test_*.py files — skipping pytest. Smoke coverage runs post-deploy."
           fi


### PR DESCRIPTION
## Summary

Adds a lightweight pre-merge gate for haystack-service. The workflow runs on PRs into `develop`/`master`/`main` and on pushes to `develop`:

- Installs `requirements.txt`
- Validates that `main`, `haystack_pipeline`, `tools`, `personas` import cleanly
- Runs `pytest` if any `test_*.py` files exist (currently none — informational)

Full coverage moves to the post-deploy staging-smoke workflow (Phase C).

Sprint 1 / Task A3 of `/Users/alec/Projects/antsa/docs/superpowers/plans/2026-04-29-pipeline-refactor.md`.

## Test plan

- [x] Workflow YAML lints
- [ ] CI run green on this PR