### PR TITLE
ci: source-branch check for master PRs

### DIFF
--- a/.github/workflows/source-branch-check.yml
+++ b/.github/workflows/source-branch-check.yml
@@ -1,0 +1,21 @@
+name: Source branch
+
+# Blocks PRs into master that originate from any branch other than develop.
+# Required status check on master per branch protection ruleset.
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  develop-only:
+    name: develop-only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch is develop
+        run: |
+          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+            echo "::error::PRs into master must come from 'develop'. Got: '${{ github.head_ref }}'"
+            exit 1
+          fi
+          echo "Source branch is develop. OK."


### PR DESCRIPTION
Sprint 2 / Task B2 of the pipeline refactor plan.

Adds required check `Source branch / develop-only` to enforce master←develop only.

Note: this workflow only triggers on PRs into `master`, so it will not run on this PR. That is expected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>