### PR TITLE
ci: trigger staging-smoke after staging deploy

### DIFF
--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -80,6 +80,24 @@ jobs:
         publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
         package: './deploy'
 
+    - name: 'Trigger staging smoke (after staging deploy)'
+      if: success() && env.DEPLOY_ENV == 'staging'
+      run: |
+        curl -fsS -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.INFRA_DISPATCH_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/antsa-pty-ltd/infra/dispatches \
+          -d '{
+            "event_type": "staging-deployed",
+            "client_payload": {
+              "service": "haystack",
+              "country": "au",
+              "sha": "${{ github.sha }}",
+              "ref": "${{ github.ref }}"
+            }
+          }'
+
     - name: 'Notify Teams on develop failure'
       # Inlined (rather than `uses:` infra/.github/actions/teams-notify)
       # because haystack is a public repo and can't pull composite actions


### PR DESCRIPTION
Sprint 3 / Task C3 of pipeline refactor plan.

On successful `develop` → staging deploy, posts a `repository_dispatch` (event_type: `staging-deployed`) to `antsa-pty-ltd/infra`. The `staging-smoke.yml` workflow there listens for this and runs the cross-service Playwright suite against deployed staging.

## Required follow-up

This PR is **inert until** the user creates the dispatch token:

1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - Token name: `infra-dispatch-token`
   - Resource owner: `antsa-pty-ltd`
   - Repository access: only `infra`
   - Permissions: Contents → read & write
   - Expiry: 1 year
2. Add the token as `INFRA_DISPATCH_TOKEN` secret in this repo.

Until then, the new `Trigger staging smoke` step will fail with HTTP 401 — but it runs *after* the deploy completes, so a missing/invalid token does not block deploys.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
