### PR TITLE
ci: trigger infra/staging-smoke after staging deploy

### DIFF
--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -80,12 +80,22 @@ jobs:
         publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
         package: './deploy'
 
+    - name: 'Mint infra dispatch token (GitHub App)'
+      if: success() && env.DEPLOY_ENV == 'staging'
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.ANTSA_CI_APP_ID }}
+        private-key: ${{ secrets.ANTSA_CI_APP_PRIVATE_KEY }}
+        owner: antsa-pty-ltd
+        repositories: infra
+
     - name: 'Trigger staging smoke (after staging deploy)'
       if: success() && env.DEPLOY_ENV == 'staging'
       run: |
         curl -fsS -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.INFRA_DISPATCH_TOKEN }}" \
+          -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/antsa-pty-ltd/infra/dispatches \
           -d '{


### PR DESCRIPTION
## Summary
- Replace PAT-based infra dispatch with GitHub App token minting (matches api repo pattern landed on develop)
- Uses `ANTSA_CI_APP_ID` + `ANTSA_CI_APP_PRIVATE_KEY` org secrets, scoped to the `infra` repo

## Test plan
- [ ] Required check passes (`Haystack - Test / Lint + Imports + Pytest`)
- [ ] Verify `repository_dispatch` lands in `infra` after next staging deploy