### PR TITLE
ci: make post-deploy smoke trigger best-effort

### DIFF
--- a/.github/workflows/deploy-haystack-au.yml
+++ b/.github/workflows/deploy-haystack-au.yml
@@ -80,9 +80,11 @@ jobs:
         publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
         package: './deploy'
 
+    # continue-on-error: cron-fired smoke is the canonical trigger; this is best-effort fast feedback.
     - name: 'Mint infra dispatch token (GitHub App)'
       if: success() && env.DEPLOY_ENV == 'staging'
       id: app-token
+      continue-on-error: true
       uses: actions/create-github-app-token@v1
       with:
         app-id: ${{ secrets.ANTSA_CI_APP_ID }}
@@ -92,6 +94,7 @@ jobs:
 
     - name: 'Trigger staging smoke (after staging deploy)'
       if: success() && env.DEPLOY_ENV == 'staging'
+      continue-on-error: true
       run: |
         curl -fsS -X POST \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the GitHub App token mint step and the staging smoke dispatch step in `deploy-haystack-au.yml`
- The `ANTSA_CI_APP` only has `contents: read` on `infra`, so the dispatch returns 403 — but the 30-min cron in `infra` triggers smoke regardless, so this is best-effort fast feedback only

## Test plan
- [ ] Required check `Haystack - Test / Lint + Imports + Pytest` passes