### PR TITLE
fix(personas): enforce concise WEB_ASSISTANT responses (bug 256)

### DIFF
--- a/personas.py
+++ b/personas.py
@@ -125,6 +125,13 @@ Sessions: search_sessions, validate_sessions, semantic_search_sessions, load_ses
 Analysis: get_loaded_sessions, get_session_content, analyze_loaded_session, analyze_session_content
 Documents: get_templates, set_selected_template, select_template_by_name, check_document_readiness, generate_document_from_loaded, generate_document_auto, get_generated_documents, refine_document
 
+# RESPONSE FORMAT
+- **Always be concise.** Default to bullet points or short paragraphs of ≤80 words.
+- Lead with the most actionable information.
+- Use bullet points (- item) for lists of 2+ items.
+- Only expand to longer prose when generating a clinical document or when explicitly asked.
+- Never pad responses with filler phrases like "Certainly!" or "Great question!".
+
 # NOTES
 - Use human-readable page names: "Messages" not "messages_page"
 - Plan before tool calls - think through data needs and sequence


### PR DESCRIPTION
## Summary

Single fix for ANTSA backlog **bug #256** — practitioners reported the ANTSAbot replies were too long to read mid-session.

Adds an explicit `# RESPONSE FORMAT` block to the WEB_ASSISTANT persona system prompt:
- Default to bullet points or short paragraphs of ≤80 words
- Lead with the most actionable information
- Use `- item` lists for 2+ items
- Only expand for clinical-document generation or when explicitly asked
- Drop filler openings like "Certainly!" / "Great question!"

The JAIMEE_THERAPIST persona is untouched (client-facing tone needs the longer, warmer responses).

## Test plan

- [x] Bug 256 regression spec passes end-to-end (`infra/e2e/.../clinic-antsabot-bugs.spec.ts`)
- [ ] CI required check: `Haystack - Test / Lint + Imports + Pytest`

## Companion PRs

- web: `feat/scribe-mobile-responsive` → develop (UI/UX fixes)
- api: `chore/ci-consolidate` → develop (file send-to-client + auth/dictated-notes)
- infra: `test/e2e-scribe-mobile-responsive` → develop (regression specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
