### PR TITLE
fix(personas): exempt rewrite/transform tasks from WEB_ASSISTANT brevity (bug 125)

### DIFF
--- a/personas.py
+++ b/personas.py
@@ -58,6 +58,7 @@ class PersonaManager:
 - For empty results (0 sessions, nothing loaded, no homework): one sentence stating the fact + one follow-up question. Do NOT pad with bullets restating "0" in different ways.
 - NEVER show UUIDs, client_ids, session_ids, or internal identifiers to the user. Use them internally for tool calls only.
 - Long-form output (documents, reports) is exempt from these constraints.
+- TEXT TRANSFORMATION TASKS are exempt from brevity: when the user asks you to rewrite, reword, restate, rephrase, edit, paraphrase, expand, summarise, translate, or change the tone/formality of text they have provided in this conversation, return the full transformed text. Preserve the substantive content and structure of the source — do NOT compress a multi-sentence paragraph into a single line or a couple of bullets. Match the approximate length of the source unless the user explicitly asked for a shorter version.
 
 ## 3. Context Awareness
 - UI state (currentClient, loadedSessions, selectedTemplate, generatedDocuments) is injected into your context


### PR DESCRIPTION
## Summary
- Bug 125 root cause: the WEB_ASSISTANT brevity rule was over-applying to rewrite/restate/tone-change requests. When the practitioner pasted a paragraph and asked "rewrite the above in a more formal tone", the bot retained the prior-turn context but compressed its rewrite to a single line instead of producing a proper formal-tone version.
- Fix: add an explicit carve-out in the WEB_ASSISTANT system prompt for text-transformation tasks (rewrite, reword, restate, rephrase, edit, paraphrase, expand, summarise, translate, change tone/formality). Instruct the bot to return the full transformed text matching the source length.
- The session/history wiring is correct end-to-end (verified by reading web → API socket gateway → haystack WS + session_manager); the bug was purely in the system prompt.

## Test plan
- [x] Reproduced bug 125 against staging with `bug-125-ai-assistant-context-loss.spec.ts` — bot returned 83-char hyper-compressed reply, failing part B
- [ ] Verify spec passes on staging after this deploys (haystack auto-deploys to AU on merge to develop)