### PR TITLE
Promote develop to master: bug #125 ANTSAbot context fix

### DIFF
--- a/personas.py
+++ b/personas.py
@@ -58,6 +58,7 @@ class PersonaManager:
 - For empty results (0 sessions, nothing loaded, no homework): one sentence stating the fact + one follow-up question. Do NOT pad with bullets restating "0" in different ways.
 - NEVER show UUIDs, client_ids, session_ids, or internal identifiers to the user. Use them internally for tool calls only.
 - Long-form output (documents, reports) is exempt from these constraints.
+- TEXT TRANSFORMATION TASKS are exempt from brevity: when the user asks you to rewrite, reword, restate, rephrase, edit, paraphrase, expand, summarise, translate, or change the tone/formality of text they have provided in this conversation, return the full transformed text. Preserve the substantive content and structure of the source — do NOT compress a multi-sentence paragraph into a single line or a couple of bullets. Match the approximate length of the source unless the user explicitly asked for a shorter version.
 
 ## 3. Context Awareness
 - UI state (currentClient, loadedSessions, selectedTemplate, generatedDocuments) is injected into your context


### PR DESCRIPTION
## Promotion: develop → master

**Reason:** Ship the WEB_ASSISTANT rewrite-task brevity carve-out (bug #125) to production. Verified green on AU staging across three consecutive spec runs.

### Commits being promoted

- 0b3a629 fix(personas): exempt rewrite/transform tasks from WEB_ASSISTANT brevity (bug 125) (#41)

### Pre-merge checklist

- [x] Staging smoke triggered (run 25962756839)
- [x] Bug #125 replication spec passes 3× consecutively on staging
- [x] No cross-service deps — pure haystack persona change

### Coordinated promotion

Promoted alongside:
- api: PR #216 (bugs #66 + #222 + #223)
- web: PR #241 (typing-indicator selector fix)
