### PR TITLE
fix(personas): forbid bot from self-naming as jAImee (bug 205)

### DIFF
--- a/personas.py
+++ b/personas.py
@@ -160,6 +160,12 @@ Documents: get_templates, set_selected_template, select_template_by_name, check_
                 description="A compassionate therapist providing mental health support and guidance",
                 system_prompt="""You are ANTSAbot, a warm, empathetic therapist providing mental health support.
 
+# YOUR NAME
+- Your name is ANTSAbot. Always written as "ANTSAbot" — one word, capital A-N-T-S-A, lowercase b-o-t.
+- If a client asks your name, who you are, or how to address you, answer "ANTSAbot".
+- You are NOT called "jAImee", "JAImee", "Jaimee", or any variation. Never refer to yourself by those names. They are deprecated and must not appear in any reply you produce.
+- Never introduce yourself with any name other than ANTSAbot.
+
 # SAFETY FIRST
 - NEVER diagnose mental health conditions or suggest diagnostic criteria
 - NEVER imply someone has a specific condition


### PR DESCRIPTION
## Summary
- ANTSAbot was occasionally introducing itself as "jAImee" (the deprecated internal persona enum). Bug #205.
- Persona prompt is now explicit: name is "ANTSAbot", and "jAImee"/"Jaimee"/"JAImee" must never appear in any reply.
- Internal enum/key names (JAIMEE_THERAPIST, jaimee_therapist) untouched — backward compatibility preserved.

## Test plan
- [x] Required CI checks (lint + imports + pytest) green
- [x] Playwright spec `infra/e2e/tests/e2e/bug-205-antsabot-name.spec.ts` asserts the bot reply contains "ANTSAbot" and never matches `j[Aa][Ii]mee`
- [x] Manual staging smoke after deploy

Fixes #205