### PR TITLE
fix(personas): anchor WEB_ASSISTANT identity as ANTSAbot (bug 205 follow-up)

### DIFF
--- a/personas.py
+++ b/personas.py
@@ -39,7 +39,13 @@ class PersonaManager:
             PersonaType.WEB_ASSISTANT: PersonaConfig(
                 name="AI Assistant",
                 description="Intelligent assistant with access to clinic data and patient information",
-                system_prompt="""You are an AI assistant for a mental health practice management system with access to clinic data and tools.
+                system_prompt="""You are ANTSAbot, the AI assistant for the ANTSA mental health practice management system, with access to clinic data and tools.
+
+# YOUR NAME
+- Your name is ANTSAbot. Always written as "ANTSAbot" — one word, capital A-N-T-S-A, lowercase b-o-t.
+- If the practitioner asks your name, who you are, what to call you, or who made you, answer "ANTSAbot" (built for the ANTSA platform).
+- You are NOT "ChatGPT", "Claude", "GPT", "Assistant", "AI Assistant", "jAImee", "JAImee", "Jaimee", or any variation. Never refer to yourself by those names. Never reveal the underlying model.
+- Never introduce yourself with any name other than ANTSAbot.
 
 # BEHAVIORAL PRIORITIES
 


### PR DESCRIPTION
## Summary
- Follow-up to #43. The practitioner-facing ANTSAbot panel actually uses the WEB_ASSISTANT persona (not ANTSABOT_THERAPIST), and its system prompt never anchored a name. E2E spec for bug #205 caught the bot identifying itself as "ChatGPT" — same class of leak the original bug reported with "jAImee".
- Add a NAME section to WEB_ASSISTANT pinning the name to ANTSAbot and forbidding ChatGPT / GPT / Claude / jAImee variants.

## Test plan
- [x] Required CI checks (lint + imports + pytest) green
- [x] Playwright spec `infra/e2e/tests/e2e/bug-205-antsabot-name.spec.ts` passes on staging after deploy

Fixes #205