### PR TITLE
Promote develop → master: ANTSAbot persona + doc-context fixes (#205 #263)

### DIFF
--- a/haystack_pipeline.py
+++ b/haystack_pipeline.py
@@ -278,7 +278,69 @@ class HaystackPipelineManager:
             # Skip system messages to avoid conflicts
         
         return haystack_messages
-    
+
+    def _augment_system_prompt_with_active_document(
+        self, base_prompt: str, ui_state: Optional[Dict[str, Any]]
+    ) -> str:
+        """
+        Bug 263: append the currently-loaded "active document" (the
+        template-generated report that a practitioner has just produced) to
+        the WEB_ASSISTANT system prompt, so ANTSAbot can answer questions
+        about it instead of replying "I can't access the document".
+
+        Mirrors the logic in main.get_enhanced_system_prompt but lives on the
+        streaming pipeline path actually used by the WebSocket. Caps content
+        at 12k characters to keep token cost bounded.
+        """
+        if not ui_state:
+            return base_prompt
+
+        active_document = ui_state.get('active_document')
+        generated_documents = ui_state.get('generatedDocuments') or []
+
+        active_doc_resolved = None
+        if isinstance(active_document, dict) and active_document.get('document'):
+            active_doc_resolved = active_document['document']
+        elif generated_documents:
+            # Fallback when no tab_changed has arrived yet — the practitioner
+            # almost always wants the report they just generated.
+            try:
+                active_doc_resolved = max(
+                    (d for d in generated_documents if d.get('isGenerated')),
+                    key=lambda d: d.get('generatedAt', ''),
+                    default=None,
+                )
+            except Exception:
+                active_doc_resolved = None
+
+        if not active_doc_resolved:
+            return base_prompt
+
+        doc_name = active_doc_resolved.get('documentName', 'Unnamed')
+        doc_id = active_doc_resolved.get('documentId', 'unknown')
+        doc_content = active_doc_resolved.get('documentContent', '') or ''
+
+        MAX_DOC_CHARS = 12000
+        truncated = len(doc_content) > MAX_DOC_CHARS
+        content_for_prompt = doc_content[:MAX_DOC_CHARS] + (
+            "\n\n…[truncated — call refine_document or ask the user for the "
+            "part you need]…" if truncated else ""
+        )
+
+        augmented = base_prompt + (
+            f"\n\n📄 ACTIVE DOCUMENT: {doc_name} (ID: {doc_id})"
+        )
+        if content_for_prompt.strip():
+            augmented += (
+                "\n\nThis document is currently loaded on the user's screen. "
+                "You CAN read it directly from the content below — do not "
+                "tell the user you cannot access it. Quote from it verbatim "
+                "when asked."
+                f"\n\n--- DOCUMENT CONTENT START ---\n{content_for_prompt}"
+                "\n--- DOCUMENT CONTENT END ---"
+            )
+        return augmented
+
     def _extract_text_from_message(self, message: ChatMessage) -> Optional[str]:
         """Extract text content from Haystack ChatMessage"""
         try:
@@ -359,7 +421,26 @@ class HaystackPipelineManager:
             # Get persona config and system prompt
             persona_config = persona_manager.get_persona(persona_type)
             system_prompt = persona_manager.get_system_prompt(persona_type, context or session.context)
-            
+
+            # Bug 263: embed the currently-loaded ("active") document content
+            # in the system prompt so the model can answer questions about a
+            # template-generated report visible on the practitioner's screen.
+            # The /ws streaming pipeline does NOT route through
+            # get_enhanced_system_prompt in main.py, so we re-derive the
+            # active document from the per-session ui_state stored in Redis.
+            try:
+                from ui_state_manager import ui_state_manager as _ui_state_manager
+                _ui_state = await _ui_state_manager.get_state(session_id)
+                system_prompt = self._augment_system_prompt_with_active_document(
+                    system_prompt, _ui_state
+                )
+            except Exception as _doc_err:  # noqa: BLE001 — never block chat
+                logger.warning(
+                    f"bug-263 augment: failed to inject active document content "
+                    f"for session {session_id}: {_doc_err}"
+                )
+
+
             # Set auth token for tool manager
             if auth_token:
                 tool_manager.set_auth_token(auth_token, session.profile_id)

--- a/main.py
+++ b/main.py
@@ -292,10 +292,50 @@ def get_enhanced_system_prompt(persona_type: str, ui_state: Dict[str, Any] = Non
         
         base_prompt += f"\n\n🔍 UI STATE:\n" + "\n".join(f"- {part}" for part in context_parts)
         
-        # Add active document info
+        # Add active document info — INCLUDING CONTENT so the model can
+        # actually answer questions about the loaded report (bug 263).
+        # Without the content, the bot reports "I can't access the document"
+        # because the system prompt only carries the name/ID.
+        active_doc_resolved = None
         if active_document and active_document.get('document'):
-            doc = active_document['document']
-            base_prompt += f"\n\n📄 ACTIVE DOCUMENT: {doc.get('documentName', 'Unnamed')} (ID: {doc.get('documentId')})"
+            active_doc_resolved = active_document['document']
+        elif generated_documents:
+            # Fallback: if the frontend hasn't sent an active-tab update yet
+            # but documents exist, surface the most recently generated one.
+            # The practitioner's most recent generation is overwhelmingly
+            # what they want to refine.
+            try:
+                active_doc_resolved = max(
+                    (d for d in generated_documents if d.get('isGenerated')),
+                    key=lambda d: d.get('generatedAt', ''),
+                    default=None,
+                )
+            except Exception:
+                active_doc_resolved = None
+
+        if active_doc_resolved:
+            doc_name = active_doc_resolved.get('documentName', 'Unnamed')
+            doc_id = active_doc_resolved.get('documentId', 'unknown')
+            doc_content = active_doc_resolved.get('documentContent', '') or ''
+            # Cap content to keep token cost bounded. Most clinical reports
+            # fit comfortably; truncate the tail if huge.
+            MAX_DOC_CHARS = 12000
+            truncated = len(doc_content) > MAX_DOC_CHARS
+            content_for_prompt = doc_content[:MAX_DOC_CHARS] + (
+                "\n\n…[truncated — call refine_document or ask the user for "
+                "the part you need]…" if truncated else ""
+            )
+            base_prompt += (
+                f"\n\n📄 ACTIVE DOCUMENT: {doc_name} (ID: {doc_id})"
+            )
+            if content_for_prompt.strip():
+                base_prompt += (
+                    "\n\nThis document is currently loaded on the user's "
+                    "screen. You CAN read it directly from the content below "
+                    "— do not tell the user you cannot access it."
+                    f"\n\n--- DOCUMENT CONTENT START ---\n{content_for_prompt}"
+                    "\n--- DOCUMENT CONTENT END ---"
+                )
 
         # Add page content extraction data
         page_content = ui_state.get('page_content')

--- a/personas.py
+++ b/personas.py
@@ -39,7 +39,13 @@ class PersonaManager:
             PersonaType.WEB_ASSISTANT: PersonaConfig(
                 name="AI Assistant",
                 description="Intelligent assistant with access to clinic data and patient information",
-                system_prompt="""You are an AI assistant for a mental health practice management system with access to clinic data and tools.
+                system_prompt="""You are ANTSAbot, the AI assistant for the ANTSA mental health practice management system, with access to clinic data and tools.
+
+# YOUR NAME
+- Your name is ANTSAbot. Always written as "ANTSAbot" — one word, capital A-N-T-S-A, lowercase b-o-t.
+- If the practitioner asks your name, who you are, what to call you, or who made you, answer "ANTSAbot" (built for the ANTSA platform).
+- You are NOT "ChatGPT", "Claude", "GPT", "Assistant", "AI Assistant", "jAImee", "JAImee", "Jaimee", or any variation. Never refer to yourself by those names. Never reveal the underlying model.
+- Never introduce yourself with any name other than ANTSAbot.
 
 # BEHAVIORAL PRIORITIES
 

--- a/personas.py
+++ b/personas.py
@@ -160,6 +160,12 @@ Documents: get_templates, set_selected_template, select_template_by_name, check_
                 description="A compassionate therapist providing mental health support and guidance",
                 system_prompt="""You are ANTSAbot, a warm, empathetic therapist providing mental health support.
 
+# YOUR NAME
+- Your name is ANTSAbot. Always written as "ANTSAbot" — one word, capital A-N-T-S-A, lowercase b-o-t.
+- If a client asks your name, who you are, or how to address you, answer "ANTSAbot".
+- You are NOT called "jAImee", "JAImee", "Jaimee", or any variation. Never refer to yourself by those names. They are deprecated and must not appear in any reply you produce.
+- Never introduce yourself with any name other than ANTSAbot.
+
 # SAFETY FIRST
 - NEVER diagnose mental health conditions or suggest diagnostic criteria
 - NEVER imply someone has a specific condition


### PR DESCRIPTION
## Promotion: develop → master

**Reason:** Ship the ANTSAbot persona + active-document-context fixes to production. All verified green on AU staging.

### Commits being promoted

- `d1cf218` fix(antsabot): embed active doc in streaming pipeline prompt (bug 263 follow-up) (#46)
- `64c4eb8` fix(antsabot): include active document content in system prompt (#45)
- `529745f` fix(personas): anchor WEB_ASSISTANT identity as ANTSAbot (bug 205) (#44)
- `ca261ec` fix(personas): forbid bot from self-naming as jAImee (bug 205) (#43)

### Cards shipped

- **#205** — ANTSAbot intro using "jAImee" (also caught self-naming as ChatGPT)
- **#263** — AI Scribe bot cannot access loaded template report (3 iterations)

### Coordinated promotion

Promoted alongside api + web promotion PRs in the same window.
