### PR TITLE
fix: unblock read-only AI tools and improve session summaries

### DIFF
--- a/main.py
+++ b/main.py
@@ -1011,12 +1011,25 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
 
                 # Build context for pipeline
                 ui_state = await ui_state_manager.get_state(session_id)
+
+                # Fallback: if ui_state has no page_type yet, seed it from the
+                # message-level context so tools can resolve page capabilities on
+                # the very first message (before a full UI state update arrives).
+                incoming_context = message_data.get("context", {})
+                if not ui_state.get("page_type") and incoming_context.get("page_context"):
+                    seed_state = {
+                        "page_type": incoming_context["page_context"],
+                        "page_url": incoming_context.get("page_url", ""),
+                        "client_id": incoming_context.get("client_id"),
+                        "client_name": incoming_context.get("client_name"),
+                    }
+                    await ui_state_manager.update_state(session_id, seed_state)
+                    ui_state = await ui_state_manager.get_state(session_id)
+
                 derived = _build_page_context_from_ui_state(ui_state)
-                
+
                 # Extract profile_id for session recovery
                 profile_id = message_data.get("profile_id") or message_data.get("profileId")
-                
-                incoming_context = message_data.get("context", {})
                 context_for_pipeline: Dict[str, Any] = {
                     "page_url": ui_state.get("page_url"),
                     "ui_capabilities": derived.get("capabilities", []),

--- a/tools.py
+++ b/tools.py
@@ -2066,11 +2066,11 @@ class ToolManager:
                 ui_state = ui_state_manager.get_state_sync(session_id)
                 page_capabilities = ui_state_manager.get_page_capabilities_sync(session_id)
                 
-                # UI tools require page capability
+                # UI mutation tools require page capability (read-only tools like
+                # get_loaded_sessions are always allowed since they just query state)
                 ui_tools = [
                     'set_client_selection', 'load_session_direct', 'load_multiple_sessions',
                     'set_selected_template', 'select_template_by_name', 'generate_document_from_loaded',
-                    'get_loaded_sessions', 'get_session_content', 'analyze_loaded_session'
                 ]
                 
                 if tool_name in ui_tools and tool_name not in page_capabilities:
@@ -4329,16 +4329,24 @@ Please refine the following document according to these instructions:
             # Format sessions for user-friendly display
             session_summaries = []
             for i, session in enumerate(loaded_sessions, 1):
+                # Format recording date for human readability
+                raw_date = (session.get("metadata") or {}).get("recordingDate", "")
+                recording_date = raw_date
+                if raw_date:
+                    try:
+                        from dateutil import parser as dateutil_parser
+                        dt = dateutil_parser.parse(raw_date)
+                        day = dt.day
+                        hour = dt.hour % 12 or 12
+                        recording_date = f"{day} {dt.strftime('%B %Y')}, {hour}:{dt.strftime('%M %p')}"
+                    except Exception:
+                        pass
                 session_summaries.append({
                     "index": i,
                     "session_id": session.get("sessionId", "unknown"),
                     "client_name": session.get("clientName", "Unknown Client"),
-                    "client_id": session.get("clientId", "unknown"),
-                    "has_content": bool(session.get("content", "")),
-                    "content_preview": (session.get("content", "")[:100] + "..." 
-                                      if len(session.get("content", "")) > 100 
-                                      else session.get("content", "")),
-                    "metadata": session.get("metadata", {})
+                    "recording_date": recording_date,
+                    "content": session.get("content", ""),
                 })
             
             return {


### PR DESCRIPTION
## Summary
- Removed `get_loaded_sessions`, `get_session_content`, `analyze_loaded_session` from page-gated tool restrictions — they are read-only queries that should work on any page
- On first message, seed `ui_state.page_type` from the incoming message context so tools resolve page capabilities before a full UI state update arrives
- Format recording dates as human-readable strings (e.g. "18 May 2026, 2:02 PM") instead of raw ISO timestamps
- Return full transcript content to the LLM instead of a truncated preview + technical metadata, enabling proper prose summaries

## Test plan
- [ ] Open ANTSAbot on the transcribe page, ask "Summarise this recording" — should produce a prose summary without segment counts or ISO dates
- [ ] Tools like `get_loaded_sessions` work regardless of page type
- [ ] Page-gated mutation tools (load_session_direct, set_client_selection) are still restricted

🤖 Generated with [Claude Code](https://claude.com/claude-code)