### PR TITLE
fix(startup): resolve Python 3.11 binary dynamically (Azure image rolled)

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -6,7 +6,21 @@ export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8001}
 
 VENV=/tmp/venv
-PYTHON=/opt/python/3.11.14/bin/python
+
+# Resolve the Python 3.11 binary dynamically. Azure App Service Python images
+# bundle a specific patch version under /opt/python/3.11.X/bin/python and the
+# version changes when the base image rolls (e.g. 3.11.14 → 3.11.15). A
+# hardcoded path caused exit code 127 + ContainerTimeout in production when
+# the image rolled to 20260504.4.tuxprod. Glob the latest available instead.
+PYTHON=$(ls -1d /opt/python/3.11.*/bin/python 2>/dev/null | sort -V | tail -1)
+if [ -z "$PYTHON" ] || [ ! -x "$PYTHON" ]; then
+  PYTHON=$(command -v python3.11 || command -v python3 || command -v python || true)
+fi
+if [ -z "$PYTHON" ] || [ ! -x "$PYTHON" ]; then
+  echo "[startup] FATAL: no Python 3 interpreter found under /opt/python/3.11.* or on PATH" >&2
+  exit 1
+fi
+echo "[startup] Using PYTHON=$PYTHON"
 
 # CRITICAL: Oryx injects corrupt antenv into PYTHONPATH. Nuke it entirely.
 unset PYTHONPATH


### PR DESCRIPTION
## Summary
Haystack production container has been failing to start since the Azure Python image rolled to `appsvc/python:3.11_20260504.4.tuxprod`.

```
[startup] Building venv at /tmp/venv...
startup.sh: line 24: /opt/python/3.11.14/bin/python: No such file or directory
Container has finished running with exit code: 127.
ContainerTimeout: Container did not start within expected time limit of 230s.
Site is blocked due to multiple, consecutive cold start failures.
```

## Fix
Resolve the Python 3.11 interpreter at runtime instead of hardcoding the patch version. Survives future patch rolls.

```bash
PYTHON=$(ls -1d /opt/python/3.11.*/bin/python 2>/dev/null | sort -V | tail -1)
if [ -z "$PYTHON" ] || [ ! -x "$PYTHON" ]; then
  PYTHON=$(command -v python3.11 || command -v python3 || command -v python || true)
fi
```

## Evidence
`/health` returns 503 in production right now; the user just hit the friendly "document service is temporarily unavailable" message from the API-side retry exhaustion (#239). That message is correct — Haystack is genuinely down. Bug 3 fix on the API side stops the **API** crash loop; this stops the **Haystack** crash loop.

## Test plan
- [x] `bash -n startup.sh` — shell syntax OK.
- [ ] After merge: confirm Haystack staging deploy starts (no exit 127). Staging is currently stopped so the test happens on prod-promote.
- [ ] After merge to master: confirm `https://antsa-haystack-au-production.azurewebsites.net/health` returns 200, and that a doc-gen request succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)