### PR TITLE
ci(haystack): probe /health post-deploy and fail on container crash-loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,45 @@ jobs:
           publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
           package: './deploy'
 
+      - name: Verify /health post-deploy
+        # Azure considers the deploy "successful" the moment the package is
+        # accepted, but the container can still crash-loop on startup (e.g.
+        # the 2026-05 incident where the hardcoded /opt/python/3.11.14 path
+        # in startup.sh disappeared after Azure rolled the base image,
+        # producing exit code 127 + ContainerTimeout for hours while CI
+        # showed green). Probe /health for up to 9 minutes so we fail the
+        # workflow when the container doesn't actually come up.
+        shell: bash
+        env:
+          APP_NAME: ${{ env.APP_NAME }}
+          DEPLOY_ENV: ${{ env.DEPLOY_ENV }}
+        run: |
+          set -u
+          URL="https://${APP_NAME}.azurewebsites.net/health"
+          if [ "${DEPLOY_ENV}" = "production" ]; then
+            RG="PRODUCTION"
+          else
+            RG="rg-antsa-staging"
+          fi
+          echo "Probing ${URL} for up to 540s (cold start budget)..."
+          end=$(( $(date +%s) + 540 ))
+          attempt=0
+          while [ "$(date +%s)" -lt "${end}" ]; do
+            attempt=$((attempt + 1))
+            body=$(curl -sS -m 20 -w $'\n%{http_code}' "${URL}" || true)
+            code=$(printf '%s' "${body}" | tail -n1)
+            payload=$(printf '%s' "${body}" | sed '$d')
+            if [ "${code}" = "200" ] && printf '%s' "${payload}" | grep -q '"status":"healthy"'; then
+              echo "✓ ${APP_NAME} healthy after ${attempt} attempt(s): ${payload}"
+              exit 0
+            fi
+            echo "$(date -u +%H:%M:%S) attempt=${attempt} code=${code}; retrying in 10s"
+            sleep 10
+          done
+          echo "✗ ${APP_NAME} failed /health check after 540s — dumping recent logs:"
+          az webapp log tail --name "${APP_NAME}" --resource-group "${RG}" 2>&1 | head -n 100 || true
+          exit 1
+
       - name: Notify Teams on develop failure
         # Inlined (rather than `uses:` infra/.github/actions/teams-notify)
         # because haystack is a public repo and can't pull composite actions


### PR DESCRIPTION
## Summary

Yesterday's prod incident (Bug 4: exit code 127 + Azure `ContainerTimeout`) ran in a crash loop for hours while CI showed green. Root cause: `startup.sh` had a hardcoded `/opt/python/3.11.14/bin/python` path, and the Azure Python base image rolled to `3.11_20260504.4.tuxprod` so the path no longer existed. Fix for the path itself shipped in #52 — but the workflow gap that let the failure go unnoticed is still there.

Azure considers `azure/webapps-deploy@v2` successful the moment the package upload is accepted. It does not verify the container actually starts. This PR closes that gap by probing `/health` after deploy and failing the workflow if the container doesn't return `200 {"status":"healthy"}` within 9 minutes.

- Polls `https://antsa-haystack-au-${ENV}.azurewebsites.net/health` every 10s for up to 540s (covers worst-case cold start with pip install on fresh container).
- Asserts HTTP 200 AND body contains `"status":"healthy"` (so a generic 200 from a stub doesn't pass).
- On failure dumps `az webapp log tail … | head -100` for the failing app so the workflow log is self-debugging.
- Reuses the existing `azure/login@v2` auth context — no new credentials.
- Single step handles both `develop → staging` (RG `rg-antsa-staging`) and `master → production` (RG `PRODUCTION`).

## Why this catches Bug 4

If this had been in place yesterday, the deploy job would have failed inside the workflow within ~9 min instead of leaving prod crash-looping for hours. The 100-line log dump would have surfaced the `exit 127` / missing-Python-binary error directly in the GitHub Actions log, pointing straight at `startup.sh`.

## Test plan

- [ ] Merge to `develop`. Deploy succeeds → step prints `✓ antsa-haystack-au-staging healthy: …` and the run is green.
- [ ] To exercise the failure path, temporarily break `startup.sh` in a throwaway branch off `develop`, observe the step retry for 9 min then dump logs and fail the job. (Don't actually do this on `develop`.)
- [ ] After landing, promote `develop → master` and confirm the same step passes against `antsa-haystack-au-production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
