### PR TITLE
ci(deploy-au): dispatch staging-smoke after prod deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,34 @@ jobs:
           publish-profile: ${{ secrets.AZUREAPPSERVICE_HAYSTACK_PUBLISHPROFILE_STAGING }}
           package: './deploy'
 
+      - name: Trigger staging-smoke after prod deploy
+        # Fires the infra repo's staging-smoke workflow via repository_dispatch
+        # so the Playwright suite runs against staging immediately after each
+        # production deploy. Catches regressions like the 2026-05 Haystack
+        # exit-127 incident that the manual-only smoke didn't surface.
+        #
+        # Requires `INFRA_DISPATCH_PAT` repo secret: a PAT with `repo` scope
+        # on antsa-pty-ltd/infra. GITHUB_TOKEN cannot dispatch to another
+        # repo. If unset, this step is a no-op (the prod deploy is still
+        # considered successful).
+        if: env.DEPLOY_ENV == 'production' && success()
+        env:
+          GH_TOKEN: ${{ secrets.INFRA_DISPATCH_PAT }}
+          DISPATCH_SHA: ${{ github.sha }}
+          DISPATCH_REF: ${{ github.ref }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "INFRA_DISPATCH_PAT not set — skipping staging-smoke trigger."
+            echo "Add a PAT with repo scope on antsa-pty-ltd/infra to enable."
+            exit 0
+          fi
+          gh api -X POST /repos/antsa-pty-ltd/infra/dispatches \
+            -f event_type=post-prod-deploy-smoke \
+            -f client_payload[service]=haystack \
+            -f client_payload[sha]="${DISPATCH_SHA}" \
+            -f client_payload[ref]="${DISPATCH_REF}"
+          echo "Dispatched post-prod-deploy-smoke to infra repo."
+
       - name: Notify Teams on develop failure
         # Inlined (rather than `uses:` infra/.github/actions/teams-notify)
         # because haystack is a public repo and can't pull composite actions


### PR DESCRIPTION
## Summary

Fires `repository_dispatch` (`type: post-prod-deploy-smoke`) at `antsa-pty-ltd/infra` after a successful push-to-master production deploy, so the Playwright smoke suite runs against staging automatically. Pairs with infra PR https://github.com/antsa-pty-ltd/infra/pull/149 and api PR https://github.com/antsa-pty-ltd/api/pull/243.

Motivation: yesterday four prod bugs landed (Stripe webhook crash-loop, segment-drop on null sessionId, template 503 with no retry, **Haystack exit 127 on missing python binary in this service**) that the manual-only smoke didn't catch. Event-driven auto-trigger is the lowest-friction safety net.

## Prerequisite

The `INFRA_DISPATCH_PAT` repo secret must be added before the dispatch will fire. It needs to be a PAT (classic or fine-grained) with `repo` scope on `antsa-pty-ltd/infra`. `GITHUB_TOKEN` can't dispatch cross-repo. **Alec to provision the PAT.**

If the secret is unset, the step short-circuits with a clear log message and prod deploys still succeed — so this PR is safe to merge before the PAT is configured.

## Test plan

- [ ] Merge to develop. The new step is gated on `env.DEPLOY_ENV == 'production'`, so the develop->staging auto-deploy fired by this merge will not exercise the new step.
- [ ] Alec adds `INFRA_DISPATCH_PAT` secret.
- [ ] Promote develop->master. On successful prod deploy, confirm an entry appears at https://github.com/antsa-pty-ltd/infra/actions/workflows/staging-smoke.yml triggered by `repository_dispatch` with `client_payload.service=haystack`.
