### PR TITLE
fix(agent): forward profileid header on API tool callbacks (final doc-gen fix)

### DIFF
--- a/agents/document_agent.py
+++ b/agents/document_agent.py
@@ -236,11 +236,12 @@ class DocumentExplorationAgent:
         template_content: str,
         authorization: Optional[str] = None,
         generation_id: Optional[str] = None,
-        emit_progress_func = None
+        emit_progress_func = None,
+        profileid: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Let the agent autonomously explore sessions and decide when to generate.
-        
+
         Args:
             session_ids: List of session IDs to explore
             template_name: Name of the document template
@@ -248,12 +249,15 @@ class DocumentExplorationAgent:
             authorization: Authorization header for API calls
             generation_id: Generation ID for progress tracking
             emit_progress_func: Function to emit progress updates (optional)
-            
+            profileid: Profile ID header — forwarded to API tool callbacks so
+                       `ExtractProfileMiddleware` can resolve `req.profile`.
+                       Without it, the API tenancy filter returns `[]`.
+
         Returns:
             Dict with accumulated segments and agent's decision trail
         """
         # Reset exploration context for this generation
-        reset_exploration_context(authorization, generation_id)
+        reset_exploration_context(authorization, generation_id, profileid)
         
         # Build initial message for the agent
         session_list = ", ".join(session_ids)

--- a/agents/exploration_tools.py
+++ b/agents/exploration_tools.py
@@ -22,6 +22,13 @@ class ExplorationContext:
         self.token_budget: int = 150000  # Increased to handle 10+ sessions comfortably
         self.sessions_explored: List[str] = []
         self.authorization: Optional[str] = None
+        # The caller's `profileid` HTTP header. Required when calling back to
+        # the API: `ExtractProfileMiddleware` only populates `req.profile`
+        # when this header is present, and several agent-tool endpoints
+        # (segments-by-sessions, semantic-search) use `req.profile.id` as
+        # the tenancy key. Without this forwarded header the API's filter
+        # short-circuits to `[]` and the agent collects zero segments.
+        self.profileid: Optional[str] = None
         self.generation_id: Optional[str] = None
         self._segment_ids: set = set()  # Track segment IDs for deduplication
         
@@ -76,12 +83,30 @@ def get_exploration_context() -> ExplorationContext:
     return _exploration_context
 
 
-def reset_exploration_context(authorization: str = None, generation_id: str = None):
+def reset_exploration_context(authorization: str = None, generation_id: str = None, profileid: str = None):
     """Reset exploration context for a new document generation"""
     global _exploration_context
     _exploration_context = ExplorationContext()
     _exploration_context.authorization = authorization
+    _exploration_context.profileid = profileid
     _exploration_context.generation_id = generation_id
+
+
+def _api_headers(context: "ExplorationContext") -> Dict[str, str]:
+    """Build the header dict forwarded on every API tool callback.
+
+    Both `Authorization` and `profileid` are required:
+      - `Authorization` (JWT) passes the API's `IsUserGuard`.
+      - `profileid` is consumed by `ExtractProfileMiddleware`, which sets
+        `req.profile`. Without it, `req.profile.id` is undefined on the
+        API side and the tenancy filter returns `[]`.
+    """
+    headers: Dict[str, str] = {}
+    if context.authorization:
+        headers["Authorization"] = context.authorization
+    if context.profileid:
+        headers["profileid"] = context.profileid
+    return headers
 
 
 async def peek_session(
@@ -114,7 +139,7 @@ async def peek_session(
                     "session_ids": [session_id],
                     "limit_per_session": num_segments
                 },
-                headers={"Authorization": context.authorization} if context.authorization else {}
+                headers=_api_headers(context)
             )
             response.raise_for_status()
             response_data = response.json()
@@ -189,7 +214,7 @@ async def search_session(
                     "limit": max_results,
                     "similarity_threshold": 0.3  # Lower threshold for better results
                 },
-                headers={"Authorization": context.authorization} if context.authorization else {}
+                headers=_api_headers(context)
             )
             response.raise_for_status()
             response_data = response.json()
@@ -256,7 +281,7 @@ async def pull_full_session(
                     "session_ids": [session_id],
                     "limit_per_session": 1000  # High limit to get all segments
                 },
-                headers={"Authorization": context.authorization} if context.authorization else {}
+                headers=_api_headers(context)
             )
             response.raise_for_status()
             response_data = response.json()

--- a/document_generation/agentic_endpoint.py
+++ b/document_generation/agentic_endpoint.py
@@ -327,14 +327,18 @@ For more information, please review our Terms of Service at www.ANTSA.com.au."""
         if not agent:
             raise HTTPException(status_code=500, detail="Document agent not initialized")
         
-        # Let agent autonomously explore and decide (with real-time reasoning updates)
+        # Let agent autonomously explore and decide (with real-time reasoning updates).
+        # `profileid` is forwarded to API tool callbacks alongside `authorization`
+        # so the API can resolve `req.profile` — required for the tenancy filter
+        # on segments-by-sessions / semantic-search to return non-empty results.
         exploration_result = await agent.explore_and_decide(
             session_ids=session_ids,
             template_name=template.get('name', 'Unknown'),
             template_content=template_content,
             authorization=authorization,
             generation_id=generation_id,
-            emit_progress_func=emit_progress_func
+            emit_progress_func=emit_progress_func,
+            profileid=profileid,
         )
         
         if not exploration_result['success']:


### PR DESCRIPTION
## Summary — fix the last layer of the doc-gen empty-content bug

After api PRs #284 / #286 / #288 / #290 the agent's tool callbacks reach the API with a valid JWT — but every callback still returns `{"segments": []}`. Confirmed in prod 2026-05-24 03:23 UTC: 10 `pull_full_session` calls succeed (no 401s) but each returns zero segments, despite the practitioner having `practitioner_clients` access to the client of all 10 transcripts.

**Root cause.** The API's `ExtractProfileMiddleware` only populates `req.profile` when the `profileid` HTTP header is present. Haystack's agent tools forward only `Authorization`, so `req.profile` is undefined on every callback. `req.profile?.id ?? req.user?.profileId` was the api-side fallback — but some login flows don't include `profileId` in the JWT payload, so the fallback also yields `undefined`. `filterAccessibleTranscriptIds(undefined, ids)` short-circuits to `[]`.

**Why this is Haystack-side, not API-side.** Haystack already receives `profileid` on the inbound `/generate-document-from-template` request from the API — it just wasn't being plumbed through to the agent or its tool callbacks. Forwarding it is strictly simpler than auditing every login path to guarantee profileId in the JWT.

## Fix

- `ExplorationContext.profileid` (new field).
- `reset_exploration_context(authorization, generation_id, profileid)`.
- New `_api_headers(context)` helper emits both `Authorization` and `profileid` on every tool callback. Replaces 3 hand-built header dicts in `exploration_tools.py`.
- `explore_and_decide` and `agentic_endpoint` thread `profileid` through.

## Test plan

- [ ] CI green
- [ ] Staging smoke (haystack staging): trigger doc-gen, confirm haystack logs show `Total segments collected > 0`.
- [ ] Final confirmation: log into AU prod web, run a doc-gen — content should populate.
