### PR TITLE
Promote develop to master: doc-gen profileid forwarding (#64 + #65)

### DIFF
--- a/agents/document_agent.py
+++ b/agents/document_agent.py
@@ -236,11 +236,12 @@ class DocumentExplorationAgent:
         template_content: str,
         authorization: Optional[str] = None,
         generation_id: Optional[str] = None,
-        emit_progress_func = None
+        emit_progress_func = None,
+        profileid: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Let the agent autonomously explore sessions and decide when to generate.
-        
+
         Args:
             session_ids: List of session IDs to explore
             template_name: Name of the document template
@@ -248,12 +249,15 @@ class DocumentExplorationAgent:
             authorization: Authorization header for API calls
             generation_id: Generation ID for progress tracking
             emit_progress_func: Function to emit progress updates (optional)
-            
+            profileid: Profile ID header — forwarded to API tool callbacks so
+                       `ExtractProfileMiddleware` can resolve `req.profile`.
+                       Without it, the API tenancy filter returns `[]`.
+
         Returns:
             Dict with accumulated segments and agent's decision trail
         """
         # Reset exploration context for this generation
-        reset_exploration_context(authorization, generation_id)
+        reset_exploration_context(authorization, generation_id, profileid)
         
         # Build initial message for the agent
         session_list = ", ".join(session_ids)

--- a/agents/exploration_tools.py
+++ b/agents/exploration_tools.py
@@ -22,6 +22,13 @@ class ExplorationContext:
         self.token_budget: int = 150000  # Increased to handle 10+ sessions comfortably
         self.sessions_explored: List[str] = []
         self.authorization: Optional[str] = None
+        # The caller's `profileid` HTTP header. Required when calling back to
+        # the API: `ExtractProfileMiddleware` only populates `req.profile`
+        # when this header is present, and several agent-tool endpoints
+        # (segments-by-sessions, semantic-search) use `req.profile.id` as
+        # the tenancy key. Without this forwarded header the API's filter
+        # short-circuits to `[]` and the agent collects zero segments.
+        self.profileid: Optional[str] = None
         self.generation_id: Optional[str] = None
         self._segment_ids: set = set()  # Track segment IDs for deduplication
         
@@ -76,12 +83,30 @@ def get_exploration_context() -> ExplorationContext:
     return _exploration_context
 
 
-def reset_exploration_context(authorization: str = None, generation_id: str = None):
+def reset_exploration_context(authorization: str = None, generation_id: str = None, profileid: str = None):
     """Reset exploration context for a new document generation"""
     global _exploration_context
     _exploration_context = ExplorationContext()
     _exploration_context.authorization = authorization
+    _exploration_context.profileid = profileid
     _exploration_context.generation_id = generation_id
+
+
+def _api_headers(context: "ExplorationContext") -> Dict[str, str]:
+    """Build the header dict forwarded on every API tool callback.
+
+    Both `Authorization` and `profileid` are required:
+      - `Authorization` (JWT) passes the API's `IsUserGuard`.
+      - `profileid` is consumed by `ExtractProfileMiddleware`, which sets
+        `req.profile`. Without it, `req.profile.id` is undefined on the
+        API side and the tenancy filter returns `[]`.
+    """
+    headers: Dict[str, str] = {}
+    if context.authorization:
+        headers["Authorization"] = context.authorization
+    if context.profileid:
+        headers["profileid"] = context.profileid
+    return headers
 
 
 async def peek_session(
@@ -114,7 +139,7 @@ async def peek_session(
                     "session_ids": [session_id],
                     "limit_per_session": num_segments
                 },
-                headers={"Authorization": context.authorization} if context.authorization else {}
+                headers=_api_headers(context)
             )
             response.raise_for_status()
             response_data = response.json()
@@ -189,7 +214,7 @@ async def search_session(
                     "limit": max_results,
                     "similarity_threshold": 0.3  # Lower threshold for better results
                 },
-                headers={"Authorization": context.authorization} if context.authorization else {}
+                headers=_api_headers(context)
             )
             response.raise_for_status()
             response_data = response.json()
@@ -256,7 +281,7 @@ async def pull_full_session(
                     "session_ids": [session_id],
                     "limit_per_session": 1000  # High limit to get all segments
                 },
-                headers={"Authorization": context.authorization} if context.authorization else {}
+                headers=_api_headers(context)
             )
             response.raise_for_status()
             response_data = response.json()

--- a/document_generation/agentic_endpoint.py
+++ b/document_generation/agentic_endpoint.py
@@ -327,14 +327,18 @@ For more information, please review our Terms of Service at www.ANTSA.com.au."""
         if not agent:
             raise HTTPException(status_code=500, detail="Document agent not initialized")
         
-        # Let agent autonomously explore and decide (with real-time reasoning updates)
+        # Let agent autonomously explore and decide (with real-time reasoning updates).
+        # `profileid` is forwarded to API tool callbacks alongside `authorization`
+        # so the API can resolve `req.profile` — required for the tenancy filter
+        # on segments-by-sessions / semantic-search to return non-empty results.
         exploration_result = await agent.explore_and_decide(
             session_ids=session_ids,
             template_name=template.get('name', 'Unknown'),
             template_content=template_content,
             authorization=authorization,
             generation_id=generation_id,
-            emit_progress_func=emit_progress_func
+            emit_progress_func=emit_progress_func,
+            profileid=profileid,
         )
         
         if not exploration_result['success']:

--- a/tests/test_exploration_tools_headers.py
+++ b/tests/test_exploration_tools_headers.py
@@ -1,0 +1,188 @@
+"""
+Unit tests proving the doc-gen agent now forwards BOTH `Authorization` and
+`profileid` headers on every API tool callback.
+
+Background. Pre-fix, the agent only forwarded `Authorization`. The API's
+`ExtractProfileMiddleware` only populates `req.profile` when the `profileid`
+header is present; without it, the API's tenancy filter
+(`filterAccessibleTranscriptIds`) received `undefined` for the profile id,
+short-circuited to `[]`, and the agent collected zero segments. End-user
+symptom: empty document body. Reported 2026-05-24.
+
+This test mocks `httpx.AsyncClient` and asserts the exact headers each agent
+tool sends. If a future change drops `profileid` again, this test fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Make repo importable when run from anywhere.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agents.exploration_tools import (  # noqa: E402
+    ExplorationContext,
+    _api_headers,
+    get_exploration_context,
+    peek_session,
+    pull_full_session,
+    reset_exploration_context,
+    search_session,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def isolated_context():
+    """Reset the module-global context before each test."""
+    reset_exploration_context(
+        authorization="Bearer eyJ.test.jwt",
+        generation_id="gen-1",
+        profileid="profile-uuid-abc",
+    )
+    yield
+    reset_exploration_context()
+
+
+class _CapturingClient:
+    """Minimal stand-in for `httpx.AsyncClient` that captures the headers."""
+
+    captured: List[Dict[str, Any]] = []
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        pass
+
+    async def post(self, url, json=None, headers=None, **_kwargs):
+        type(self).captured.append({"url": url, "json": json, "headers": headers or {}})
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json = MagicMock(return_value={"segments": []})
+        resp.raise_for_status = MagicMock()
+        return resp
+
+
+@pytest.fixture
+def capture_http():
+    _CapturingClient.captured = []
+    with patch("agents.exploration_tools.httpx.AsyncClient", _CapturingClient):
+        yield _CapturingClient
+
+
+# ── _api_headers (the building block) ─────────────────────────────────────
+
+
+class TestApiHeaders:
+    def test_includes_both_headers_when_context_has_both(self):
+        ctx = ExplorationContext()
+        ctx.authorization = "Bearer xyz"
+        ctx.profileid = "prof-1"
+        headers = _api_headers(ctx)
+        assert headers == {"Authorization": "Bearer xyz", "profileid": "prof-1"}
+
+    def test_omits_profileid_when_unset(self):
+        ctx = ExplorationContext()
+        ctx.authorization = "Bearer xyz"
+        # profileid intentionally left None
+        headers = _api_headers(ctx)
+        assert headers == {"Authorization": "Bearer xyz"}
+
+    def test_omits_authorization_when_unset(self):
+        ctx = ExplorationContext()
+        ctx.profileid = "prof-1"
+        headers = _api_headers(ctx)
+        assert headers == {"profileid": "prof-1"}
+
+    def test_returns_empty_dict_when_both_unset(self):
+        assert _api_headers(ExplorationContext()) == {}
+
+
+# ── reset_exploration_context wires profileid through ─────────────────────
+
+
+class TestResetExplorationContext:
+    def test_persists_profileid_on_the_context(self):
+        reset_exploration_context(
+            authorization="Bearer abc",
+            generation_id="gen-1",
+            profileid="prof-xyz",
+        )
+        ctx = get_exploration_context()
+        assert ctx.authorization == "Bearer abc"
+        assert ctx.profileid == "prof-xyz"
+        assert ctx.generation_id == "gen-1"
+
+    def test_defaults_profileid_to_none_for_legacy_callers(self):
+        reset_exploration_context(authorization="Bearer abc", generation_id="gen-1")
+        ctx = get_exploration_context()
+        assert ctx.profileid is None
+
+
+# ── Each agent tool forwards both headers on its API callback ─────────────
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestPullFullSessionForwardsProfileid:
+    def test_includes_authorization_and_profileid_in_outbound_headers(self, capture_http):
+        _run(pull_full_session("session-1"))
+        assert len(capture_http.captured) == 1, "expected exactly one outbound call"
+        call = capture_http.captured[0]
+        assert "/ai/transcripts/segments-by-sessions" in call["url"]
+        assert call["headers"].get("Authorization") == "Bearer eyJ.test.jwt"
+        assert call["headers"].get("profileid") == "profile-uuid-abc"
+
+
+class TestPeekSessionForwardsProfileid:
+    def test_includes_authorization_and_profileid_in_outbound_headers(self, capture_http):
+        _run(peek_session("session-1"))
+        assert len(capture_http.captured) == 1
+        call = capture_http.captured[0]
+        assert "/ai/transcripts/segments-by-sessions" in call["url"]
+        assert call["headers"].get("Authorization") == "Bearer eyJ.test.jwt"
+        assert call["headers"].get("profileid") == "profile-uuid-abc"
+
+
+class TestSearchSessionForwardsProfileid:
+    def test_includes_authorization_and_profileid_in_outbound_headers(self, capture_http):
+        _run(search_session("session-1", query="topic"))
+        assert len(capture_http.captured) == 1
+        call = capture_http.captured[0]
+        assert "/ai/semantic-search" in call["url"]
+        assert call["headers"].get("Authorization") == "Bearer eyJ.test.jwt"
+        assert call["headers"].get("profileid") == "profile-uuid-abc"
+
+
+class TestRegressionGuardLegacyAuthOnlyHeader:
+    """
+    Regression guard: the pre-fix behaviour sent only `{"Authorization":
+    ...}` -- if a future refactor accidentally restores that shape, these
+    assertions will catch it.
+    """
+
+    def test_no_tool_call_omits_profileid_when_context_has_one(self, capture_http):
+        _run(pull_full_session("s1"))
+        _run(peek_session("s2"))
+        _run(search_session("s3", query="x"))
+        assert len(capture_http.captured) == 3
+        for call in capture_http.captured:
+            assert "profileid" in call["headers"], (
+                f"call to {call['url']} omitted profileid -- regression of the "
+                f"empty-content doc-gen bug (2026-05-24)"
+            )


### PR DESCRIPTION
## Promotion: develop → master (haystack)

Final layer of the doc-gen empty-content saga.

- **#64** fix(agent): forward profileid header alongside Authorization on API tool callbacks
- **#65** test(agent): pin profileid forwarding on every tool callback

### Evidence

Prod log 2026-05-24 03:23 UTC after the API-side fixes shipped: agent `pull_full_session` succeeded with HTTP 200 for all 10 sessions but every response was `{"segments": []}`. Direct DB query confirmed the caller has `practitioner_clients` access to all 10 transcripts' client. The only path that produces 200 + empty segments is `filterAccessibleTranscriptIds(undefined, ...) => []`, which fires when the API's `req.profile?.id ?? req.user?.profileId` both yield `undefined`. Root cause: Haystack tools forward only `Authorization`, not `profileid`, so the API's `ExtractProfileMiddleware` never populates `req.profile`; and the JWT-claim fallback is unreliable because some login flows omit `profileId` from the JWT payload.

### Fix (in this PR)

- `ExplorationContext.profileid` (new field).
- `reset_exploration_context(authorization, generation_id, profileid)`.
- New `_api_headers(context)` helper emits BOTH headers on every tool callback.
- `explore_and_decide` + `agentic_endpoint` thread `profileid` through.

### Test

10 new pytest unit tests in `tests/test_exploration_tools_headers.py` mocking `httpx.AsyncClient` and asserting captured headers. Each agent tool (peek_session, pull_full_session, search_session) verifies both headers on its outbound call. Plus a regression guard that fails if any future change drops profileid.

Local: 10/10 passed. CI: Lint + Imports + Pytest passed on both PRs.

### Pre-merge checklist

- [x] Required checks green
- [x] Staging deploy succeeded
- [x] Unit tests pin the new header forwarding
- [ ] Production smoke: trigger doc-gen, confirm `Total segments collected > 0` in haystack prod logs
