### PR TITLE
fix(scribe): honour web Refine tab edits in doc generator

### DIFF
--- a/document_generation/generator.py
+++ b/document_generation/generator.py
@@ -176,17 +176,59 @@ Focus particularly on preserving the integrity of therapeutic interventions and 
         if generation_instructions:
             system_prompt += f"\n\nADDITIONAL CONTEXT AND INSTRUCTIONS FROM PRACTITIONER:\n{generation_instructions}\n\nIMPORTANT: This additional context should be integrated into your understanding of the transcript and used to correct any assumptions or add missing background information. Regenerate the document incorporating this new information.\n"
         
-        # Check if this is a modification/regeneration request
-        is_regeneration = template_content.startswith("CRITICAL INSTRUCTIONS FOR AI ASSISTANT:")
-        
+        # Check if this is a modification/regeneration request.
+        #
+        # Two refinement framings exist in the wild, both must route here:
+        #   1. Haystack's own `_refine_document` tool (tools.py) wraps its
+        #      refinement prompt with a "CRITICAL INSTRUCTIONS FOR AI ASSISTANT:"
+        #      header — the legacy marker.
+        #   2. The web Refine tab (web commit fc8c394a4 / PR #277) sends a
+        #      prompt framed with "ORIGINAL DOCUMENT:" + "REQUESTED MODIFICATIONS:"
+        #      markers and a closing "REFINED DOCUMENT:" cue.
+        #
+        # Before this fix, only (1) was detected. (2) fell through to the
+        # "normal generation" branch, which wrapped the user's refine prompt
+        # as if it were a fresh template and re-rendered it against the
+        # transcripts — silently ignoring the user's edit (e.g. "change
+        # Hermione to Sally-Anne" returned a doc still saying Hermione).
+        # See 2026-05-25 scribe refine outage.
+        is_legacy_regeneration = template_content.startswith(
+            "CRITICAL INSTRUCTIONS FOR AI ASSISTANT:"
+        )
+        is_web_refinement = (
+            "ORIGINAL DOCUMENT:" in template_content
+            and "REQUESTED MODIFICATIONS:" in template_content
+        )
+        is_regeneration = is_legacy_regeneration or is_web_refinement
+
         # Build source content section (transcript and/or notes)
         source_content = ""
         if transcript_text:
             source_content += f"**Session Transcript:**\n{transcript_text}\n"
         if notes_text:
             source_content += f"\n{notes_text}\n"
-        
-        if is_regeneration:
+
+        if is_web_refinement:
+            # Web Refine tab: the template_content is itself a complete,
+            # edit-framed prompt (original document + requested modifications
+            # already embedded). Pass it through with minimal wrapping and an
+            # explicit instruction NOT to regenerate from transcripts. The
+            # transcript is deliberately omitted from the user prompt — its
+            # presence has historically tempted the model to regenerate from
+            # scratch and lose the user's edit.
+            logger.info(
+                "🪄 Web refinement detected (ORIGINAL DOCUMENT / REQUESTED MODIFICATIONS markers); "
+                "routing to refinement prompt builder"
+            )
+            user_prompt = f"""You are editing an existing clinical document. Apply ONLY the requested modifications. Do NOT regenerate the document from session transcripts. Preserve all unchanged content verbatim — section headings, clinical tone, and structure must remain identical.
+
+**Client:** {client_name}
+**Practitioner:** {practitioner_name}
+**Today's Date:** {today}
+
+{template_content}
+"""
+        elif is_legacy_regeneration:
             user_prompt = f"""Modify the existing document based on the modification request.
 
 **Client:** {client_name}

--- a/tests/test_refinement_routing.py
+++ b/tests/test_refinement_routing.py
@@ -61,8 +61,7 @@ change Hermione to Sally-Anne
 REFINED DOCUMENT:"""
 
 
-@pytest.mark.asyncio
-async def test_web_refinement_routes_to_edit_prompt():
+def test_web_refinement_routes_to_edit_prompt():
     """
     Web Refine tab framing must route to the refinement prompt builder, NOT
     the normal generation branch. The user prompt sent to OpenAI MUST:
@@ -90,7 +89,7 @@ async def test_web_refinement_routes_to_edit_prompt():
         },
     ]
 
-    await generate_document_from_context(
+    asyncio.run(generate_document_from_context(
         segments=transcript_segments,
         template={
             "id": "tmpl-1",
@@ -101,7 +100,7 @@ async def test_web_refinement_routes_to_edit_prompt():
         practitioner_info={"id": "p-1", "name": "Dr Smith"},
         generation_instructions=None,
         openai_client=openai_client,
-    )
+    ))
 
     assert len(captured) == 1, "OpenAI should be called exactly once"
     messages = captured[0]["messages"]
@@ -127,8 +126,7 @@ async def test_web_refinement_routes_to_edit_prompt():
     assert "How have you been since our last session?" not in user_prompt
 
 
-@pytest.mark.asyncio
-async def test_legacy_regeneration_marker_still_routes_to_edit_prompt():
+def test_legacy_regeneration_marker_still_routes_to_edit_prompt():
     """
     Haystack's own `_refine_document` tool emits a refinement prompt starting
     with "CRITICAL INSTRUCTIONS FOR AI ASSISTANT:". This existing path must
@@ -148,14 +146,14 @@ Please refine the following document according to these instructions:
 Dr Smith met with Sally-Anne Jones today.
 """
 
-    await generate_document_from_context(
+    asyncio.run(generate_document_from_context(
         segments=[],
         template={"id": "t", "name": "Refine", "content": legacy_template},
         client_info={"id": "c-1", "name": "Sally-Anne"},
         practitioner_info={"id": "p-1", "name": "Dr Smith"},
         generation_instructions=None,
         openai_client=openai_client,
-    )
+    ))
 
     assert len(captured) == 1
     user_prompt = next(
@@ -166,8 +164,7 @@ Dr Smith met with Sally-Anne Jones today.
     assert "use first names only" in user_prompt
 
 
-@pytest.mark.asyncio
-async def test_normal_template_still_routes_to_generation():
+def test_normal_template_still_routes_to_generation():
     """
     A plain template (no refinement markers) must still flow through the
     normal generation path, embedding the transcript as Source Content.
@@ -175,7 +172,7 @@ async def test_normal_template_still_routes_to_generation():
     captured: List[Dict[str, Any]] = []
     openai_client = _make_openai_client(captured)
 
-    await generate_document_from_context(
+    asyncio.run(generate_document_from_context(
         segments=[
             {
                 "speaker": "Therapist",
@@ -193,7 +190,7 @@ async def test_normal_template_still_routes_to_generation():
         practitioner_info={"id": "p-1", "name": "Dr Smith"},
         generation_instructions=None,
         openai_client=openai_client,
-    )
+    ))
 
     user_prompt = next(
         m["content"] for m in captured[0]["messages"] if m["role"] == "user"

--- a/tests/test_refinement_routing.py
+++ b/tests/test_refinement_routing.py
@@ -1,0 +1,203 @@
+"""
+Regression tests for the scribe Refine tab — 2026-05-25 outage.
+
+Background. Sally-Anne reported that the web Refine tab silently ignored her
+edit instructions (e.g. "change Hermione to Sally-Anne" still rendered the
+document with Hermione). Root cause: `generate_document_from_context` only
+detected refinement framings starting with `"CRITICAL INSTRUCTIONS FOR AI
+ASSISTANT:"` (the marker Haystack's own `tools.py::_refine_document` emits).
+The web Refine tab (web PR #277) sends a different framing — `ORIGINAL
+DOCUMENT:` / `REQUESTED MODIFICATIONS:` markers. That framing fell through
+to the "normal generation" branch, which wrapped the refine-prompt as if it
+were a fresh template and re-ran agentic generation against the transcripts,
+silently dropping the user's edit.
+
+These tests pin the routing behaviour. Without the fix, the web-refinement
+test fails (the user prompt contains transcript context instead of the
+refine-only edit framing).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from document_generation.generator import generate_document_from_context  # noqa: E402
+
+
+def _make_openai_client(captured: List[Dict[str, Any]]) -> MagicMock:
+    """A mock OpenAI client that captures the messages it was called with."""
+    client = MagicMock()
+
+    async def fake_create(**kwargs):
+        captured.append(kwargs)
+        response = MagicMock()
+        choice = MagicMock()
+        choice.message.content = "REFINED DOCUMENT CONTENT"
+        choice.finish_reason = "stop"
+        response.choices = [choice]
+        response.usage = MagicMock(total_tokens=42)
+        return response
+
+    client.chat.completions.create = AsyncMock(side_effect=fake_create)
+    return client
+
+
+WEB_REFINEMENT_TEMPLATE = """You are refining an existing clinical document. Return the FULL refined document, preserving its original structure, section headings, and clinical tone. Apply ONLY the requested modifications — do NOT regenerate from scratch from the transcripts.
+
+ORIGINAL DOCUMENT:
+SOAP note. S: Hermione reported low mood... O: Hermione presented as... A: ... P: ...
+
+REQUESTED MODIFICATIONS:
+change Hermione to Sally-Anne
+
+REFINED DOCUMENT:"""
+
+
+@pytest.mark.asyncio
+async def test_web_refinement_routes_to_edit_prompt():
+    """
+    Web Refine tab framing must route to the refinement prompt builder, NOT
+    the normal generation branch. The user prompt sent to OpenAI MUST:
+      - tell the model to apply ONLY the requested modifications
+      - tell it NOT to regenerate from transcripts
+      - contain the original document and the requested modification verbatim
+      - NOT include the session transcript as a "Source Content" section
+        (its presence tempts the model to regenerate from scratch)
+    """
+    captured: List[Dict[str, Any]] = []
+    openai_client = _make_openai_client(captured)
+
+    transcript_segments = [
+        {
+            "speaker": "Therapist",
+            "text": "How have you been since our last session?",
+            "start_time": 0,
+            "transcript_id": "tx-1",
+        },
+        {
+            "speaker": "Client",
+            "text": "Not great, my mood has been low.",
+            "start_time": 5,
+            "transcript_id": "tx-1",
+        },
+    ]
+
+    await generate_document_from_context(
+        segments=transcript_segments,
+        template={
+            "id": "tmpl-1",
+            "name": "SOAP note",
+            "content": WEB_REFINEMENT_TEMPLATE,
+        },
+        client_info={"id": "c-1", "name": "Sally-Anne"},
+        practitioner_info={"id": "p-1", "name": "Dr Smith"},
+        generation_instructions=None,
+        openai_client=openai_client,
+    )
+
+    assert len(captured) == 1, "OpenAI should be called exactly once"
+    messages = captured[0]["messages"]
+    user_prompt = next(m["content"] for m in messages if m["role"] == "user")
+
+    # The refine-framed markers must reach the model verbatim.
+    assert "ORIGINAL DOCUMENT:" in user_prompt
+    assert "REQUESTED MODIFICATIONS:" in user_prompt
+    assert "change Hermione to Sally-Anne" in user_prompt
+
+    # Edit framing must be explicit.
+    assert "Apply ONLY the requested modifications" in user_prompt
+    assert "Do NOT regenerate" in user_prompt or "do NOT regenerate" in user_prompt
+
+    # Critically — the normal-generation user prompt opens with "Generate a
+    # comprehensive clinical document." and embeds the transcript under a
+    # "Source Content" / "Session Transcript" heading. Neither must appear:
+    # if they do, we've fallen through to the regeneration-from-transcript
+    # path and the user's edit will be ignored. This is the regression the
+    # 2026-05-25 outage exposed.
+    assert "Generate a comprehensive clinical document" not in user_prompt
+    assert "Session Transcript" not in user_prompt
+    assert "How have you been since our last session?" not in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_legacy_regeneration_marker_still_routes_to_edit_prompt():
+    """
+    Haystack's own `_refine_document` tool emits a refinement prompt starting
+    with "CRITICAL INSTRUCTIONS FOR AI ASSISTANT:". This existing path must
+    continue to work — the fix is additive.
+    """
+    captured: List[Dict[str, Any]] = []
+    openai_client = _make_openai_client(captured)
+
+    legacy_template = """CRITICAL INSTRUCTIONS FOR AI ASSISTANT:
+- NEVER provide diagnoses
+
+Please refine the following document according to these instructions:
+
+**Refinement Instructions:** use first names only
+
+**Original Document:**
+Dr Smith met with Sally-Anne Jones today.
+"""
+
+    await generate_document_from_context(
+        segments=[],
+        template={"id": "t", "name": "Refine", "content": legacy_template},
+        client_info={"id": "c-1", "name": "Sally-Anne"},
+        practitioner_info={"id": "p-1", "name": "Dr Smith"},
+        generation_instructions=None,
+        openai_client=openai_client,
+    )
+
+    assert len(captured) == 1
+    user_prompt = next(
+        m["content"] for m in captured[0]["messages"] if m["role"] == "user"
+    )
+    assert "Modify the existing document based on the modification request" in user_prompt
+    # Legacy path still embeds the original template verbatim.
+    assert "use first names only" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_normal_template_still_routes_to_generation():
+    """
+    A plain template (no refinement markers) must still flow through the
+    normal generation path, embedding the transcript as Source Content.
+    """
+    captured: List[Dict[str, Any]] = []
+    openai_client = _make_openai_client(captured)
+
+    await generate_document_from_context(
+        segments=[
+            {
+                "speaker": "Therapist",
+                "text": "How are you?",
+                "start_time": 0,
+                "transcript_id": "tx-1",
+            }
+        ],
+        template={
+            "id": "tmpl-1",
+            "name": "SOAP",
+            "content": "Generate a SOAP note covering Subjective, Objective, Assessment, Plan.",
+        },
+        client_info={"id": "c-1", "name": "Sally-Anne"},
+        practitioner_info={"id": "p-1", "name": "Dr Smith"},
+        generation_instructions=None,
+        openai_client=openai_client,
+    )
+
+    user_prompt = next(
+        m["content"] for m in captured[0]["messages"] if m["role"] == "user"
+    )
+    assert "Generate a comprehensive clinical document" in user_prompt
+    assert "Session Transcript" in user_prompt
+    assert "How are you?" in user_prompt


### PR DESCRIPTION
## Summary
- Detects the web Refine tab's edit-framed template (ORIGINAL DOCUMENT / REQUESTED MODIFICATIONS markers, web PR #277) in `generate_document_from_context` and routes it to a dedicated refinement prompt that tells the model to apply ONLY the requested modifications and NOT regenerate from transcripts.
- Legacy `_refine_document`-tool framing (CRITICAL INSTRUCTIONS marker) still works — fix is additive.
- Adds 3 pytest cases pinning routing behaviour; the web-refinement case fails on `develop` without this patch.

## Root cause

Sally-Anne reported on prod at ~03:46 UTC that "change Hermione to Sally-Anne" via the Refine tab returned a document still saying Hermione. Web PR #277 had deployed at ~03:37 UTC and is wired correctly. Production Haystack log:

```
2026-05-25T03:46:18Z [AGENTIC] Generating document from template: AI Conference
2026-05-25T03:46:18Z [AGENTIC] Generating from 2 sessions and 0 notes using 'AI Conference'
2026-05-25T03:46:20Z [AGENTIC] Using DocumentExplorationAgent for 2 sessions
2026-05-25T03:46:25Z Generating document: 90 segments from 2 sessions
```

The refinement framing reached Haystack but `generator.py:180` only checked for `template_content.startswith("CRITICAL INSTRUCTIONS FOR AI ASSISTANT:")`. The web sends a different prefix (`"You are refining an existing clinical document..."`), so the request fell through to the normal-generation branch, which wraps the refine prompt as if it were a template and re-renders it from 90 transcript segments. The user's edit was silently discarded.

## Test plan
- [x] `pytest tests/` — 13/13 pass with fix; web-refinement test fails without it (verified by `git stash` + rerun)
- [ ] Manual: deploy to staging, open a generated SOAP doc, hit Refine, ask to rename a single name, confirm name change and no other content drift
- [ ] Manual: invoke Jaimee's `refine_document` tool conversationally and confirm legacy path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
