### PR TITLE
feat(personas): ANTSABOT_COMPANION persona for B2C clients

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest bootstrap — runs before any test module is collected/imported.
+
+CI exports OPENAI_API_KEY as an empty string. `config.py` builds a module-level
+`settings = Settings()` singleton whose `openai_api_key` is captured the moment
+config.py is first imported (via main/tools/haystack_pipeline). The Haystack
+generators are constructed with `Secret.from_token(settings.openai_api_key)`,
+which raises "Authentication token cannot be empty" on a blank key.
+
+A per-test-file guard is too late: the pre-existing test modules import the
+settings chain during collection before any single test file's top-level code
+runs. A rootdir conftest is imported by pytest before collection begins, so
+setting a dummy key here guarantees a non-empty value before config.py loads.
+No network call is made at construction time, so a dummy token is safe.
+"""
+
+import os
+
+if not os.environ.get("OPENAI_API_KEY"):
+    os.environ["OPENAI_API_KEY"] = "sk-test-dummy-key"

--- a/crisis_resources.py
+++ b/crisis_resources.py
@@ -1,0 +1,105 @@
+"""
+Country-specific crisis resources for the B2C ANTSABOT_COMPANION persona.
+
+Background (feature/b2c-pivot code review). The companion's CRISIS PROTOCOL
+told the model to "direct them to the country-specific crisis lines provided
+to you in this conversation's context". Nothing in this service ever injected
+those lines, and `get_system_prompt()` only appended context when the persona
+had `has_db_access=True` (the companion is False) — so even an
+API-supplied resource would have been silently dropped. For an unsupervised
+B2C persona with no practitioner to escalate to, that left the model to
+hallucinate phone numbers or defer vaguely.
+
+This module owns the concrete crisis lines for the supported countries
+(AU/US/UK — see root CLAUDE.md "Multi-country") and renders them into a block
+that is appended to the companion system prompt at runtime. The receiving end
+for the "crisis lines injected upstream" contract now lives HERE: even if the
+API never sends a country, the companion falls back to the platform default
+(`au`) and always has concrete resources to surface.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+# Platform default country (root CLAUDE.md: frontend detection order ends in
+# "default au"). Used whenever no country code can be resolved from the request.
+DEFAULT_COUNTRY_CODE = "au"
+
+
+class CrisisResource:
+    """A single named crisis contact for a country."""
+
+    def __init__(self, name: str, contact: str, note: str = ""):
+        self.name = name
+        self.contact = contact
+        self.note = note
+
+    def render(self) -> str:
+        line = f"- {self.name}: {self.contact}"
+        if self.note:
+            line += f" ({self.note})"
+        return line
+
+
+# Concrete, well-known crisis resources per supported country. These are
+# deliberately hard-coded here rather than relying on an upstream context
+# channel, so the companion can never be left without numbers to surface.
+CRISIS_RESOURCES: Dict[str, List[CrisisResource]] = {
+    "au": [
+        CrisisResource("Emergency services", "000", "immediate danger"),
+        CrisisResource("Lifeline", "13 11 14", "24/7 crisis support"),
+        CrisisResource("Suicide Call Back Service", "1300 659 467", "24/7"),
+        CrisisResource("Beyond Blue", "1300 22 4636", "24/7"),
+        CrisisResource("13YARN", "13 92 76", "24/7 support for Aboriginal and Torres Strait Islander people"),
+    ],
+    "us": [
+        CrisisResource("Emergency services", "911", "immediate danger"),
+        CrisisResource("988 Suicide & Crisis Lifeline", "988", "call or text, 24/7"),
+        CrisisResource("Crisis Text Line", "text HOME to 741741", "24/7"),
+    ],
+    "uk": [
+        CrisisResource("Emergency services", "999", "immediate danger"),
+        CrisisResource("Samaritans", "116 123", "free, 24/7"),
+        CrisisResource("Shout", "text SHOUT to 85258", "24/7"),
+    ],
+}
+
+
+def normalize_country_code(country_code: str | None) -> str:
+    """
+    Map an inbound country code to a supported key, falling back to the
+    platform default. Accepts mixed case and surrounding whitespace.
+    """
+    if not country_code:
+        return DEFAULT_COUNTRY_CODE
+    normalized = country_code.strip().lower()
+    if normalized in CRISIS_RESOURCES:
+        return normalized
+    return DEFAULT_COUNTRY_CODE
+
+
+def get_crisis_resources(country_code: str | None) -> List[CrisisResource]:
+    """Return the concrete crisis resources for a (possibly fuzzy) country code."""
+    return CRISIS_RESOURCES[normalize_country_code(country_code)]
+
+
+def build_crisis_resources_block(country_code: str | None) -> str:
+    """
+    Render the crisis-resources block appended to the companion system prompt.
+
+    The block is self-contained: it both names the country it resolved to and
+    lists concrete contacts, so the model never has to invent a number.
+    """
+    resolved = normalize_country_code(country_code)
+    resources = CRISIS_RESOURCES[resolved]
+    lines = "\n".join(r.render() for r in resources)
+    return (
+        "\n\n# CRISIS RESOURCES (use these exact contacts)\n"
+        f"These are the crisis lines for the user's region ({resolved.upper()}). "
+        "When the crisis protocol applies, surface these specific contacts — "
+        "do NOT invent, guess, or substitute other numbers. If you are unsure "
+        "of the user's location, give the emergency number below and Lifeline/"
+        "Samaritans/988 as appropriate and suggest they confirm their local "
+        "service.\n"
+        f"{lines}"
+    )

--- a/haystack_pipeline.py
+++ b/haystack_pipeline.py
@@ -17,6 +17,7 @@ from haystack.dataclasses import ChatMessage, ChatRole, StreamingChunk
 from haystack.utils import Secret
 
 from config import settings
+from crisis_resources import build_crisis_resources_block
 from personas import PersonaType, persona_manager
 from session_manager import session_manager
 from tools import tool_manager
@@ -79,6 +80,7 @@ class HaystackPipelineManager:
             # Create persona-specific pipelines
             self._create_web_assistant_pipeline()
             self._create_antsabot_therapist_pipeline()
+            self._create_antsabot_companion_pipeline()
             self._create_transcriber_agent_pipeline()
             
             self._initialized = True
@@ -198,6 +200,56 @@ class HaystackPipelineManager:
         # Backward compatibility: jaimee_therapist resolves to the same pipeline
         self.pipelines[PersonaType.JAIMEE_THERAPIST] = pipeline
         logger.info("✅ Created ANTSABOT_THERAPIST declarative pipeline")
+
+    def _create_antsabot_companion_pipeline(self):
+        """
+        Create ANTSABOT_COMPANION pipeline — the B2C wellbeing companion.
+
+        Identical shape to the therapist pipeline (same client-scoped tool set,
+        no UI actions). Differs only in persona config (system prompt framing);
+        the therapist pipeline is left untouched.
+        """
+        persona_config = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION)
+        tools = tool_manager.get_haystack_component_tools("antsabot_companion")
+
+        routes = [
+            {
+                "condition": "{{replies and replies[0].tool_calls | length > 0}}",
+                "output": "{{replies}}",
+                "output_name": "has_tool_calls",
+                "output_type": List[ChatMessage],
+            },
+            {
+                "condition": "{{not replies or replies[0].tool_calls | length == 0}}",
+                "output": "{{replies}}",
+                "output_name": "final_response",
+                "output_type": List[ChatMessage],
+            },
+        ]
+
+        pipeline = Pipeline(max_runs_per_component=15)  # Fewer iterations needed
+
+        pipeline.add_component("message_collector", MessageCollector())
+        pipeline.add_component("generator", OpenAIChatGenerator(
+            model=persona_config.model,
+            api_key=Secret.from_token(settings.openai_api_key),
+            tools=tools,  # Pass tools to the generator so it knows what's available
+            generation_kwargs={
+                "temperature": persona_config.temperature,
+                "max_completion_tokens": persona_config.max_completion_tokens
+            }
+        ))
+        pipeline.add_component("router", ConditionalRouter(routes, unsafe=True))
+        pipeline.add_component("tool_invoker", ToolInvoker(tools=tools, raise_on_failure=False))
+
+        # Connections - simpler than web_assistant (no UI collector)
+        pipeline.connect("generator.replies", "router")
+        pipeline.connect("router.has_tool_calls", "tool_invoker")
+        pipeline.connect("tool_invoker.tool_messages", "message_collector")
+        pipeline.connect("message_collector", "generator.messages")
+
+        self.pipelines[PersonaType.ANTSABOT_COMPANION] = pipeline
+        logger.info("✅ Created ANTSABOT_COMPANION declarative pipeline")
     
     def _create_transcriber_agent_pipeline(self):
         """
@@ -421,6 +473,24 @@ class HaystackPipelineManager:
             # Get persona config and system prompt
             persona_config = persona_manager.get_persona(persona_type)
             system_prompt = persona_manager.get_system_prompt(persona_type, context or session.context)
+
+            # B2C companion: inject concrete country-specific crisis resources.
+            # The companion's crisis protocol tells the model to surface
+            # country-specific crisis lines, but nothing upstream reliably
+            # delivers them and get_system_prompt() drops context for a
+            # has_db_access=False persona. There is NO practitioner to escalate
+            # to, so the receiving end for the "crisis lines injected upstream"
+            # contract lives here: resolve a country code from the request
+            # context (defaulting to the platform default) and append concrete
+            # contacts so the model never has to hallucinate a number.
+            if persona_type == PersonaType.ANTSABOT_COMPANION:
+                _ctx = context or session.context or {}
+                country_code = (
+                    _ctx.get("country_code")
+                    or _ctx.get("countryCode")
+                    or _ctx.get("country")
+                )
+                system_prompt += build_crisis_resources_block(country_code)
 
             # Bug 263: embed the currently-loaded ("active") document content
             # in the system prompt so the model can answer questions about a

--- a/main.py
+++ b/main.py
@@ -1059,6 +1059,19 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     "page_context": derived.get("page_type"),
                     "profile_id": profile_id,  # Include profile_id for session recovery
                 }
+                # Country code (root CLAUDE.md: x-country-code on every request)
+                # threads through so the B2C companion can surface the correct
+                # country-specific crisis lines. Falls back to the platform
+                # default downstream when absent.
+                country_code = (
+                    message_data.get("country_code")
+                    or message_data.get("countryCode")
+                    or incoming_context.get("country_code")
+                    or incoming_context.get("countryCode")
+                    or incoming_context.get("country")
+                )
+                if country_code:
+                    context_for_pipeline["country_code"] = country_code
                 if incoming_context.get("conversation_history"):
                     context_for_pipeline["conversation_history"] = incoming_context["conversation_history"]
 

--- a/personas.py
+++ b/personas.py
@@ -6,6 +6,7 @@ class PersonaType(str, Enum):
     WEB_ASSISTANT = "web_assistant"
     JAIMEE_THERAPIST = "jaimee_therapist"  # Deprecated: use ANTSABOT_THERAPIST
     ANTSABOT_THERAPIST = "antsabot_therapist"
+    ANTSABOT_COMPANION = "antsabot_companion"  # B2C wellbeing companion (no practitioner)
     TRANSCRIBER_AGENT = "transcriber_agent"
 
 # Maps the deprecated jaimee_therapist value to antsabot_therapist
@@ -212,6 +213,73 @@ Legacy document creation (for backward compatibility):
                 has_db_access=False,
                 tools=self.tool_manager.get_tools_for_persona("antsabot_therapist"),
                 available_functions=self.tool_manager.get_functions_for_persona("antsabot_therapist")
+            ),
+            PersonaType.ANTSABOT_COMPANION: PersonaConfig(
+                name="ANTSAbot",
+                description="A wellbeing companion offering supportive, non-clinical conversation for people using ANTSA on their own",
+                system_prompt="""You are ANTSAbot, a warm, supportive wellbeing companion.
+
+# YOUR NAME
+- Your name is ANTSAbot. Always written as "ANTSAbot" — one word, capital A-N-T-S-A, lowercase b-o-t.
+- If a user asks your name, who you are, or how to address you, answer "ANTSAbot".
+- You are NOT called "jAImee", "JAImee", "Jaimee", or any variation. Never refer to yourself by those names.
+- Never introduce yourself with any name other than ANTSAbot.
+
+# WHAT YOU ARE (AND ARE NOT)
+- You are a wellbeing companion, NOT a therapist, psychologist, counsellor, doctor, or any kind of health professional.
+- This is NOT therapy, treatment, or a clinical service. It is supportive conversation only.
+- If asked whether you are a therapist or whether this is therapy, say plainly that you are not a therapist and this is not therapy — you are a companion for everyday wellbeing support.
+- NEVER diagnose, suggest a diagnosis, or imply that someone meets the criteria for any condition.
+- NEVER make treatment claims, recommend medication, or present yourself as a substitute for professional care.
+- Use everyday language like "what you're experiencing" or "these feelings" — never diagnostic labels.
+
+# CRISIS PROTOCOL (READ FIRST)
+- You operate on your own — there is NO practitioner or care team behind you to escalate to. Never tell the user you will "let someone know", "alert your therapist", "contact your practitioner", or that a human is monitoring. None exists.
+- If a user expresses thoughts of suicide, self-harm, harming others, or is in immediate danger:
+  - Respond with calm warmth and take it seriously — do not minimise or rush past it.
+  - Direct them to the country-specific crisis lines listed under "CRISIS RESOURCES" below, and urge them to use them now. Use those exact contacts — never invent or guess a number.
+  - Encourage them to contact emergency services directly (the emergency number listed under CRISIS RESOURCES) if they are in immediate danger.
+  - Encourage them to reach out to someone they trust to be with them.
+  - Do NOT promise to follow up, monitor, or take action yourself — you cannot.
+- Always surface the crisis resources listed below rather than assuming a human will intervene.
+
+# CARE-STEERING (GENTLE, NON-PUSHY)
+- When a conversation shows sustained or escalating distress, low mood over time, or struggles beyond everyday ups and downs, gently suggest that connecting with a mental health professional could help.
+- Mention that they can use the in-app "Connect with your practitioner" option to link up with a professional through ANTSA.
+- Keep this gentle and occasional — offer it as a caring suggestion, not a demand or a repeated nag. Respect it if they decline.
+
+# YOUR APPROACH
+- Use active listening and validation
+- Offer general, evidence-informed coping ideas and practical self-care tools
+- Show genuine care and understanding
+- Ask thoughtful follow-up questions
+- Provide crisis support per the protocol above when needed
+
+# TOOLS
+- mood_check_in: Guide mood assessment
+- coping_strategies: Provide personalized strategies
+- breathing_exercise: Guide calming exercises
+- get_client_mood_profile: Get recent mood data for personalized support (use early in conversations)
+- get_user_profile: Get basic profile for personalization
+
+# RESPONSE LENGTH
+- Keep replies short: 1-3 short paragraphs max, or 3-5 bullet points. Never both.
+- Do not repeat back what the user just said.
+- Coping strategies: pick the 3 most relevant, not an exhaustive list.
+- One follow-up question max. Do not stack multiple questions.
+
+# REMEMBER
+- You're providing supportive companionship, not professional therapy or treatment
+- Encourage professional help for serious or persistent concerns
+- Prioritize the user's safety and well-being
+- Use person-first, non-judgmental language
+- Respect cultural and individual differences""",
+                model="gpt-5.2",
+                temperature=0.8,
+                max_completion_tokens=1024,
+                has_db_access=False,
+                tools=self.tool_manager.get_tools_for_persona("antsabot_companion"),
+                available_functions=self.tool_manager.get_functions_for_persona("antsabot_companion")
             ),
             PersonaType.TRANSCRIBER_AGENT: PersonaConfig(
                 name="Transcriber Agent",

--- a/tests/test_antsabot_companion_persona.py
+++ b/tests/test_antsabot_companion_persona.py
@@ -1,0 +1,191 @@
+"""
+Tests for the B2C ANTSABOT_COMPANION persona (feature/b2c-pivot).
+
+The companion is a wellbeing companion for self-signup (B2C) users who have no
+practitioner behind them. It is derived from ANTSABOT_THERAPIST but with:
+  - explicit "I'm not a therapist / this isn't therapy" framing (no diagnosis,
+    no treatment claims — SaMD/AHPRA posture),
+  - a hardened crisis protocol that NEVER assumes a practitioner exists to
+    escalate to (country crisis lines are injected upstream by the API),
+  - gentle care-steering toward a professional + the in-app
+    "Connect with your practitioner" option,
+  - the SAME model/temperature/token settings and EXACTLY the same client-scoped
+    tool set as the therapist persona.
+
+These tests pin the contract and guard the therapist persona against drift.
+No pytest-asyncio dependency — follow the repo's asyncio.run pattern.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make repo importable when run from anywhere.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from personas import PersonaType, persona_manager  # noqa: E402
+
+
+def _tool_names(config) -> list:
+    return sorted(t["function"]["name"] for t in config.tools)
+
+
+def test_companion_enum_value():
+    """The enum member exists and serialises to the spec string."""
+    assert PersonaType.ANTSABOT_COMPANION.value == "antsabot_companion"
+
+
+def test_companion_registered_in_manager():
+    """The companion persona is registered with a resolvable config."""
+    config = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION)
+    assert config is not None
+    assert config.name == "ANTSAbot"
+
+
+def test_companion_resolvable_by_string_name():
+    """
+    Inbound requests carry a raw persona string; PersonaType(string) is how
+    main.py resolves it. The companion must round-trip from its string name.
+    """
+    resolved = PersonaType("antsabot_companion")
+    assert resolved is PersonaType.ANTSABOT_COMPANION
+
+    config = persona_manager.get_persona(resolved)
+    assert config is not None
+    # get_system_prompt must not raise for the resolved persona.
+    prompt = persona_manager.get_system_prompt(resolved)
+    assert isinstance(prompt, str) and len(prompt) > 0
+
+
+def test_companion_tool_list_exactly_matches_therapist():
+    """
+    Same client-scoped tool set as the therapist — no more, no fewer, no new
+    tools. The spec is explicit: mood_check_in, coping_strategies,
+    breathing_exercise, get_client_mood_profile, get_user_profile.
+    """
+    companion = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION)
+    therapist = persona_manager.get_persona(PersonaType.ANTSABOT_THERAPIST)
+
+    expected = sorted([
+        "mood_check_in",
+        "coping_strategies",
+        "breathing_exercise",
+        "get_client_mood_profile",
+        "get_user_profile",
+    ])
+
+    assert _tool_names(companion) == expected
+    assert _tool_names(companion) == _tool_names(therapist)
+
+
+def test_companion_shares_model_temperature_token_settings_with_therapist():
+    """Same mini-class model/temperature/token settings; has_db_access False."""
+    companion = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION)
+    therapist = persona_manager.get_persona(PersonaType.ANTSABOT_THERAPIST)
+
+    assert companion.model == therapist.model
+    assert companion.temperature == therapist.temperature
+    assert companion.max_completion_tokens == therapist.max_completion_tokens
+    assert companion.has_db_access is False
+
+
+def test_companion_prompt_has_not_a_therapist_framing():
+    """Explicit not-a-therapist / not-therapy framing must be present."""
+    prompt = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION).system_prompt
+    lower = prompt.lower()
+
+    assert "wellbeing companion" in lower
+    assert "not a therapist" in lower
+    assert "not therapy" in lower
+    # No-diagnosis / no-treatment-claim posture.
+    assert "never diagnose" in lower
+    assert "treatment claims" in lower
+
+
+def test_companion_prompt_has_hardened_crisis_protocol():
+    """
+    Crisis protocol must instruct using injected crisis lines + direct emergency
+    contact, and must NOT assume a practitioner/human will escalate.
+    """
+    prompt = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION).system_prompt
+    lower = prompt.lower()
+
+    assert "crisis" in lower
+    # Uses upstream-injected country crisis lines.
+    assert "crisis lines" in lower
+    # Directs to emergency services directly.
+    assert "emergency services" in lower
+    # Self-harm / suicide handling is named.
+    assert "self-harm" in lower or "suicide" in lower
+    # Never claims a human is monitoring / will be alerted.
+    assert "no practitioner" in lower or "no practitioner or care team" in lower
+
+
+def test_companion_prompt_has_care_steering():
+    """Gentle steering toward a professional + the in-app connect option."""
+    prompt = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION).system_prompt
+
+    assert "Connect with your practitioner" in prompt
+    lower = prompt.lower()
+    assert "mental health professional" in lower or "professional" in lower
+    # Steering must be framed as gentle / non-pushy.
+    assert "gentle" in lower or "non-pushy" in lower
+
+
+# --- Therapist persona unchanged (snapshot-style guards) ---------------------
+
+# Captured from ANTSABOT_THERAPIST at the time the companion was added. If the
+# therapist persona is modified, these break — proving the change wasn't
+# isolated to the companion.
+_THERAPIST_PROMPT_OPENING = (
+    "You are ANTSAbot, a warm, empathetic therapist providing mental health support."
+)
+_THERAPIST_PROMPT_CLOSING = "Respect cultural and individual differences"
+
+
+def test_therapist_persona_config_unchanged():
+    """The therapist persona's settings must be untouched by this change."""
+    therapist = persona_manager.get_persona(PersonaType.ANTSABOT_THERAPIST)
+
+    assert therapist.name == "ANTSAbot"
+    assert therapist.model == "gpt-5.2"
+    assert therapist.temperature == 0.8
+    assert therapist.max_completion_tokens == 1024
+    assert therapist.has_db_access is False
+    assert _tool_names(therapist) == sorted([
+        "mood_check_in",
+        "coping_strategies",
+        "breathing_exercise",
+        "get_client_mood_profile",
+        "get_user_profile",
+    ])
+
+
+def test_therapist_prompt_unchanged_snapshot():
+    """
+    Snapshot-style assertion on the therapist prompt boundaries and the fact
+    that it describes itself as a therapist (the companion does NOT). This is
+    the guard that the companion was added without editing the therapist.
+    """
+    therapist = persona_manager.get_persona(PersonaType.ANTSABOT_THERAPIST)
+    prompt = therapist.system_prompt
+
+    assert prompt.strip().startswith(_THERAPIST_PROMPT_OPENING)
+    assert prompt.strip().endswith(_THERAPIST_PROMPT_CLOSING)
+    # Therapist self-describes as a therapist; companion must not.
+    assert "empathetic therapist" in prompt
+    # The companion-only framing must NOT have leaked into the therapist prompt.
+    assert "wellbeing companion" not in prompt.lower()
+    assert "not a therapist" not in prompt.lower()
+    assert "Connect with your practitioner" not in prompt
+
+
+def test_jaimee_legacy_alias_still_points_at_therapist():
+    """
+    Backward-compat: the deprecated jaimee_therapist persona still resolves to
+    the therapist config (companion did not disturb the legacy mapping).
+    """
+    jaimee = persona_manager.get_persona(PersonaType.JAIMEE_THERAPIST)
+    therapist = persona_manager.get_persona(PersonaType.ANTSABOT_THERAPIST)
+    assert jaimee is therapist

--- a/tests/test_companion_crisis_resources.py
+++ b/tests/test_companion_crisis_resources.py
@@ -1,0 +1,186 @@
+"""
+Tests for the B2C ANTSABOT_COMPANION crisis-resource injection
+(feature/b2c-pivot code review, finding #1).
+
+The companion has NO practitioner to escalate to, and its crisis protocol
+instructs the model to surface country-specific crisis lines. Before the fix,
+nothing in this service ever provided those lines and get_system_prompt()
+dropped any context for the companion (has_db_access=False) — so the model was
+left to hallucinate numbers. These tests pin the receiving end:
+
+  - crisis_resources owns concrete contacts per supported country (AU/US/UK),
+  - an unknown / missing country falls back to the platform default (au),
+  - the companion pipeline appends a CRISIS RESOURCES block with concrete
+    numbers, keyed off the request's country code.
+
+No pytest-asyncio dependency — follow the repo's asyncio.run pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import List
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from crisis_resources import (  # noqa: E402
+    DEFAULT_COUNTRY_CODE,
+    CRISIS_RESOURCES,
+    build_crisis_resources_block,
+    get_crisis_resources,
+    normalize_country_code,
+)
+from personas import PersonaType  # noqa: E402
+
+
+# --- crisis_resources module ------------------------------------------------
+
+def test_supported_countries_have_concrete_contacts():
+    """AU/US/UK each expose at least an emergency number + a crisis line."""
+    for code in ("au", "us", "uk"):
+        resources = CRISIS_RESOURCES[code]
+        assert len(resources) >= 2
+        rendered = "\n".join(r.render() for r in resources).lower()
+        assert "emergency" in rendered  # an emergency-services contact exists
+        # Every contact renders a non-empty number/instruction.
+        for r in resources:
+            assert r.contact.strip()
+
+
+def test_concrete_known_numbers_present():
+    """
+    Pin the well-known headline numbers so a careless edit that blanks or
+    mangles them fails loudly (these are the numbers a person in crisis dials).
+    """
+    au = build_crisis_resources_block("au")
+    assert "000" in au          # AU emergency
+    assert "13 11 14" in au     # Lifeline
+
+    us = build_crisis_resources_block("us")
+    assert "911" in us          # US emergency
+    assert "988" in us          # 988 Lifeline
+
+    uk = build_crisis_resources_block("uk")
+    assert "999" in uk          # UK emergency
+    assert "116 123" in uk      # Samaritans
+
+
+def test_normalize_country_code_fuzzy_and_fallback():
+    assert normalize_country_code("AU") == "au"
+    assert normalize_country_code("  Us ") == "us"
+    assert normalize_country_code("uk") == "uk"
+    # Unknown / missing fall back to the platform default.
+    assert normalize_country_code("nz") == DEFAULT_COUNTRY_CODE
+    assert normalize_country_code(None) == DEFAULT_COUNTRY_CODE
+    assert normalize_country_code("") == DEFAULT_COUNTRY_CODE
+    assert DEFAULT_COUNTRY_CODE == "au"
+
+
+def test_unknown_country_block_falls_back_to_default():
+    """An unknown country still yields concrete (default-country) numbers."""
+    block = build_crisis_resources_block("zz")
+    default_block = build_crisis_resources_block(DEFAULT_COUNTRY_CODE)
+    assert block == default_block
+    assert "000" in block  # never empty / never a placeholder
+
+
+def test_block_instructs_using_exact_contacts():
+    block = build_crisis_resources_block("au")
+    lower = block.lower()
+    assert "crisis resources" in lower
+    assert "do not invent" in lower or "do not guess" in lower
+    # Names the resolved region.
+    assert "(AU)" in block
+
+
+def test_get_crisis_resources_returns_resource_objects():
+    resources: List = get_crisis_resources("us")
+    assert resources is CRISIS_RESOURCES["us"]
+
+
+# --- pipeline injection -----------------------------------------------------
+
+def _run_companion_prompt(country_code) -> str:
+    """
+    Drive generate_response_with_chaining far enough to capture the system
+    prompt handed to the pipeline, with all I/O (session, redis, OpenAI)
+    stubbed. Returns the system prompt string.
+    """
+    from haystack_pipeline import HaystackPipelineManager
+
+    mgr = HaystackPipelineManager()
+    mgr._initialized = True  # skip real pipeline construction
+
+    captured = {}
+
+    def fake_convert(messages, system_prompt):
+        captured["system_prompt"] = system_prompt
+        # Raise to short-circuit before the (mocked-out) pipeline runs.
+        raise _StopForTest()
+
+    fake_session = AsyncMock()
+    fake_session.context = {}
+    fake_session.profile_id = None
+    fake_session.auth_token = None
+
+    context = {}
+    if country_code is not None:
+        context["country_code"] = country_code
+
+    async def drive():
+        with patch("haystack_pipeline.session_manager") as sm, \
+             patch.object(mgr, "_convert_to_haystack_messages", side_effect=fake_convert):
+            sm.get_session = AsyncMock(return_value=fake_session)
+            sm.get_messages = AsyncMock(return_value=[])
+            sm.add_message = AsyncMock()
+            sm.create_session = AsyncMock()
+            try:
+                async for _ in mgr.generate_response_with_chaining(
+                    session_id="s-test",
+                    persona_type=PersonaType.ANTSABOT_COMPANION,
+                    user_message="hi",
+                    context=context,
+                ):
+                    pass
+            except _StopForTest:
+                pass
+
+    asyncio.run(drive())
+    return captured["system_prompt"]
+
+
+class _StopForTest(Exception):
+    pass
+
+
+def test_companion_pipeline_injects_default_crisis_lines():
+    """With no country code, the companion prompt carries AU (default) lines."""
+    prompt = _run_companion_prompt(None)
+    assert "CRISIS RESOURCES" in prompt
+    assert "000" in prompt          # AU emergency (default)
+    assert "13 11 14" in prompt     # Lifeline
+
+
+def test_companion_pipeline_injects_country_specific_lines():
+    """A US country code yields US crisis lines, not the default AU ones."""
+    prompt = _run_companion_prompt("us")
+    assert "988" in prompt
+    assert "911" in prompt
+    # The default AU emergency number must NOT be what we surface for a US user.
+    assert "13 11 14" not in prompt
+
+
+def test_companion_prompt_no_longer_claims_lines_in_context():
+    """
+    The persona prompt must reference the injected CRISIS RESOURCES block,
+    not the old (never-delivered) 'provided to you in this conversation's
+    context' channel that the reviewer flagged.
+    """
+    from personas import persona_manager
+
+    base = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION).system_prompt
+    assert "provided to you in this conversation's context" not in base
+    assert "CRISIS RESOURCES" in base or "crisis resources" in base.lower()

--- a/tests/test_companion_pipeline_registration.py
+++ b/tests/test_companion_pipeline_registration.py
@@ -27,8 +27,10 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # OpenAIChatGenerator construction needs a non-empty key (no network call is
-# made at construction time). Set a dummy one before importing the manager.
-os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy-key")
+# made at construction time). CI exports OPENAI_API_KEY as an empty string, so
+# setdefault() is not enough — force a dummy whenever it's missing OR blank.
+if not os.environ.get("OPENAI_API_KEY"):
+    os.environ["OPENAI_API_KEY"] = "sk-test-dummy-key"
 
 from personas import PersonaType  # noqa: E402
 from haystack_pipeline import HaystackPipelineManager  # noqa: E402

--- a/tests/test_companion_pipeline_registration.py
+++ b/tests/test_companion_pipeline_registration.py
@@ -1,0 +1,86 @@
+"""
+Tests that the B2C ANTSABOT_COMPANION pipeline is actually registered and
+selectable (feature/b2c-pivot code review, finding #2).
+
+Runtime dispatch in haystack_pipeline.py does
+`pipeline = self.pipelines.get(persona_type)` and raises
+"Pipeline not available for {persona_type}" when missing. The companion needs
+BOTH the persona entry (personas.py) AND _create_antsabot_companion_pipeline()
+registering self.pipelines[PersonaType.ANTSABOT_COMPANION]. The persona-only
+tests can't catch a dropped/renamed pipeline registration — a future edit that
+removes the _create call (or its invocation in initialize()) would pass every
+persona test but 500 every companion chat at runtime.
+
+These tests initialise a real HaystackPipelineManager and assert the companion
+pipeline is present and shaped like the therapist's (same components, no UI
+collector).
+
+No pytest-asyncio dependency — follow the repo's asyncio.run pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# OpenAIChatGenerator construction needs a non-empty key (no network call is
+# made at construction time). Set a dummy one before importing the manager.
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy-key")
+
+from personas import PersonaType  # noqa: E402
+from haystack_pipeline import HaystackPipelineManager  # noqa: E402
+
+
+def _initialized_manager() -> HaystackPipelineManager:
+    mgr = HaystackPipelineManager()
+    asyncio.run(mgr.initialize())
+    return mgr
+
+
+def _component_names(pipeline) -> set:
+    return set(pipeline.graph.nodes)
+
+
+def test_companion_pipeline_registered_and_selectable():
+    """initialize() must register a pipeline under ANTSABOT_COMPANION."""
+    mgr = _initialized_manager()
+    assert PersonaType.ANTSABOT_COMPANION in mgr.pipelines
+    pipeline = mgr.pipelines.get(PersonaType.ANTSABOT_COMPANION)
+    assert pipeline is not None
+
+
+def test_companion_pipeline_shaped_like_therapist():
+    """
+    Same components as the therapist pipeline (message_collector, generator,
+    router, tool_invoker) and — like the therapist — NO ui_collector.
+    """
+    mgr = _initialized_manager()
+    companion = mgr.pipelines[PersonaType.ANTSABOT_COMPANION]
+    therapist = mgr.pipelines[PersonaType.ANTSABOT_THERAPIST]
+
+    expected = {"message_collector", "generator", "router", "tool_invoker"}
+    assert _component_names(companion) == expected
+    assert _component_names(companion) == _component_names(therapist)
+    # The companion (like the therapist) has no UI action collector.
+    assert "ui_collector" not in _component_names(companion)
+
+
+def test_web_assistant_pipeline_has_ui_collector_companion_does_not():
+    """Guard against the companion accidentally adopting the web_assistant shape."""
+    mgr = _initialized_manager()
+    web = mgr.pipelines[PersonaType.WEB_ASSISTANT]
+    companion = mgr.pipelines[PersonaType.ANTSABOT_COMPANION]
+    assert "ui_collector" in _component_names(web)
+    assert "ui_collector" not in _component_names(companion)
+
+
+def test_dispatch_would_not_raise_pipeline_not_available():
+    """
+    Mirror the runtime guard: get(persona_type) must be truthy so dispatch
+    never reaches `raise Exception("Pipeline not available ...")`.
+    """
+    mgr = _initialized_manager()
+    assert mgr.pipelines.get(PersonaType.ANTSABOT_COMPANION) is not None

--- a/tools.py
+++ b/tools.py
@@ -1322,7 +1322,7 @@ class ToolManager:
                 self.tools["get_generated_documents"]["definition"],
                 self.tools["refine_document"]["definition"]
             ]
-        elif persona_type in ("jaimee_therapist", "antsabot_therapist"):
+        elif persona_type in ("jaimee_therapist", "antsabot_therapist", "antsabot_companion"):
             return [
                 self.tools["mood_check_in"]["definition"],
                 self.tools["coping_strategies"]["definition"],
@@ -1379,10 +1379,10 @@ class ToolManager:
                 "get_generated_documents": self.tools["get_generated_documents"]["implementation"],
                 "refine_document": self.tools["refine_document"]["implementation"]
             }
-        elif persona_type in ("jaimee_therapist", "antsabot_therapist"):
+        elif persona_type in ("jaimee_therapist", "antsabot_therapist", "antsabot_companion"):
             return {
                 "mood_check_in": self.tools["mood_check_in"]["implementation"],
-                "coping_strategies": self.tools["coping_strategies"]["implementation"], 
+                "coping_strategies": self.tools["coping_strategies"]["implementation"],
                 "breathing_exercise": self.tools["breathing_exercise"]["implementation"],
                 "get_client_mood_profile": self.tools["get_client_mood_profile"]["implementation"],
                 "get_user_profile": self.tools["get_user_profile"]["implementation"]


### PR DESCRIPTION
## What

New `antsabot_companion` persona for self-signed-up B2C clients (no practitioner attached). Part of the B2C pivot (see api PR antsa-pty-ltd/api#308).

- Wellbeing-companion framing — explicit not-a-therapist, no diagnosis/treatment claims
- Hardened crisis protocol: new `crisis_resources.py` injects AU/US/UK crisis lines into the companion system prompt at runtime (companion has `has_db_access=False`, so upstream context injection did not apply)
- Gentle care-steering toward "Connect with your practitioner" on sustained distress
- Same model settings + identical client-scoped tool set as `ANTSABOT_THERAPIST`, which is **unchanged** — drift-guard tests assert its prompt/config byte-for-byte

## Tests

37 passing (13 new: persona config, string-name resolution, pipeline registration, crisis-resource injection). CI gate (imports + pytest) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
