### PR TITLE
fix(deploy): package all root modules — crisis_resources.py dropped → haystack 503

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,18 @@ jobs:
         run: |
           mkdir deploy
 
-          # Copy application source only (no venv - built on Azure at runtime)
-          cp main.py config.py personas.py session_manager.py haystack_pipeline.py \
-             ui_state_manager.py tools.py requirements.txt startup.sh deploy/
+          # Copy application source only (no venv - built on Azure at runtime).
+          # Copy ALL root-level .py modules rather than a hardcoded list: the
+          # explicit list silently dropped crisis_resources.py when it was added
+          # (haystack_pipeline.py imports it), crashing the container on startup
+          # with ModuleNotFoundError. A glob can't drift out of sync. Test-only
+          # files (conftest.py, test_integration.py) are inert in wwwroot.
+          cp *.py requirements.txt startup.sh deploy/
           cp -r components agents document_generation utils deploy/
 
-          # Verify main.py is present
+          # Verify main.py + every root module it transitively imports made it in.
           test -f deploy/main.py || { echo "ERROR: main.py not found!"; exit 1; }
+          test -f deploy/crisis_resources.py || { echo "ERROR: crisis_resources.py not found!"; exit 1; }
 
           # Create Python entrypoint
           printf '#!/usr/bin/env python3\nimport subprocess, sys\nsys.exit(subprocess.call(["bash", "startup.sh"]))\n' > deploy/startup.py


### PR DESCRIPTION
## Root cause
Staging haystack was returning **503** (crash-looping). Container startup log:
```
File "/home/site/wwwroot/haystack_pipeline.py", line 20, in <module>
    from crisis_resources import build_crisis_resources_block
ModuleNotFoundError: No module named 'crisis_resources'
```
The deploy step in `ci.yml` copied a **hardcoded file list** that never included `crisis_resources.py` (added alongside the import in the companion-persona work). So the package shipped the import without the module → exit 1 → crash-loop → 503 → every AI smoke spec timed out ("Bot did not produce a reply"). CI's "verify imports" passed because it runs in the repo root, not against the deploy package.

**This would crash production haystack identically** when #70 is promoted (same workflow builds the prod package) — caught by the staging-smoke gate before promotion.

## Fix
Copy all root `*.py` modules instead of a drift-prone hardcoded list, so new modules can't be silently dropped. Plus an explicit presence guard for `crisis_resources.py`. Test-only files are inert in wwwroot (entrypoint is `uvicorn main:app`).

Merging to develop auto-redeploys staging haystack; I'll verify /health + a live bot reply, then re-run staging-smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)