### PR TITLE
feat: context-aware practitioner recommendations in ANTSAbot

### DIFF
--- a/haystack_pipeline.py
+++ b/haystack_pipeline.py
@@ -18,6 +18,7 @@ from haystack.utils import Secret
 
 from config import settings
 from crisis_resources import build_crisis_resources_block
+from practitioner_context import build_practitioner_context_block, fetch_practitioner_context
 from personas import PersonaType, persona_manager
 from session_manager import session_manager
 from tools import tool_manager
@@ -491,6 +492,26 @@ class HaystackPipelineManager:
                     or _ctx.get("country")
                 )
                 system_prompt += build_crisis_resources_block(country_code)
+
+            # Practitioner context: inject named-practitioner guidance so the
+            # model can give specific recommendations (e.g. "talk to Sally,
+            # your psychologist") rather than generic "seek professional help".
+            if persona_type in (PersonaType.ANTSABOT_COMPANION, PersonaType.ANTSABOT_THERAPIST):
+                try:
+                    _pract_token = auth_token or (session.auth_token if session else None)
+                    if _pract_token:
+                        _pract_info = await fetch_practitioner_context(_pract_token)
+                        system_prompt += build_practitioner_context_block(_pract_info)
+                    else:
+                        system_prompt += build_practitioner_context_block(None)
+                except Exception as _pract_err:  # noqa: BLE001 — never block chat
+                    logger.warning(
+                        f"practitioner-context: failed to fetch for session "
+                        f"{session_id}: {_pract_err}"
+                    )
+                    # Fall through — the persona prompt's fallback instructions
+                    # tell the model to assume no practitioner if the section
+                    # is absent.
 
             # Bug 263: embed the currently-loaded ("active") document content
             # in the system prompt so the model can answer questions about a

--- a/personas.py
+++ b/personas.py
@@ -203,7 +203,7 @@ Legacy document creation (for backward compatibility):
 
 # REMEMBER
 - You're providing supportive conversation, not replacing professional therapy
-- Encourage professional help for serious concerns
+- For serious concerns, refer to the PRACTITIONER CONTEXT section below (if present) for how to recommend professional support. If no practitioner context is given, encourage seeking professional help generally.
 - Prioritize client safety and well-being
 - Use person-first, non-judgmental language
 - Respect cultural and individual differences""",
@@ -234,7 +234,7 @@ Legacy document creation (for backward compatibility):
 - Use everyday language like "what you're experiencing" or "these feelings" — never diagnostic labels.
 
 # CRISIS PROTOCOL (READ FIRST)
-- You operate on your own — there is NO practitioner or care team behind you to escalate to. Never tell the user you will "let someone know", "alert your therapist", "contact your practitioner", or that a human is monitoring. None exists.
+- Whether this user has a practitioner is described in the PRACTITIONER CONTEXT section appended below (if present). Follow those instructions for how to frame professional support recommendations. If no PRACTITIONER CONTEXT section is present, assume no practitioner is available and never claim one exists.
 - If a user expresses thoughts of suicide, self-harm, harming others, or is in immediate danger:
   - Respond with calm warmth and take it seriously — do not minimise or rush past it.
   - Direct them to the country-specific crisis lines listed under "CRISIS RESOURCES" below, and urge them to use them now. Use those exact contacts — never invent or guess a number.
@@ -244,8 +244,8 @@ Legacy document creation (for backward compatibility):
 - Always surface the crisis resources listed below rather than assuming a human will intervene.
 
 # CARE-STEERING (GENTLE, NON-PUSHY)
-- When a conversation shows sustained or escalating distress, low mood over time, or struggles beyond everyday ups and downs, gently suggest that connecting with a mental health professional could help.
-- Mention that they can use the in-app "Connect with your practitioner" option to link up with a professional through ANTSA.
+- When a conversation shows sustained or escalating distress, low mood over time, or struggles beyond everyday ups and downs, gently suggest connecting with a mental health professional.
+- Follow the practitioner-specific guidance in the PRACTITIONER CONTEXT section below when steering toward professional care. If no practitioner context is present, mention that they can use the in-app "Connect with a practitioner" option to find support through ANTSA.
 - Keep this gentle and occasional — offer it as a caring suggestion, not a demand or a repeated nag. Respect it if they decline.
 
 # YOUR APPROACH

--- a/practitioner_context.py
+++ b/practitioner_context.py
@@ -1,0 +1,125 @@
+"""
+Practitioner-context injection for ANTSABOT_THERAPIST and ANTSABOT_COMPANION.
+
+The ANTSAbot personas previously gave generic "speak to a professional" advice
+regardless of whether the client had an active practitioner on the platform.
+This module resolves the client's practitioner (if any) via the NestJS API and
+renders a prompt block so the model can name the practitioner rather than
+giving vague guidance.
+
+Pattern follows crisis_resources.py — a self-contained module that builds a
+prompt block appended to the system prompt at runtime.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompt block builder
+# ---------------------------------------------------------------------------
+
+
+def build_practitioner_context_block(practitioner_info: Optional[Dict[str, Any]]) -> str:
+    """
+    Render the practitioner-context block appended to the companion/therapist
+    system prompt.
+
+    Args:
+        practitioner_info: Dict from the API endpoint with keys:
+            - hasPractitioner (bool)
+            - firstName (str) — practitioner's first name
+            - practitionerType (str) — e.g. "Psychologist"
+            - isB2c (bool) — whether the client came via B2C signup
+        Or None if the lookup failed / was skipped.
+    """
+    if practitioner_info is None or not practitioner_info.get("hasPractitioner"):
+        # Scenario C: no practitioner
+        return (
+            "\n\n# PRACTITIONER CONTEXT\n"
+            "This user does not currently have a practitioner on ANTSA.\n"
+            "When suggesting professional support, mention they can use the "
+            "\"Connect with a practitioner\" option in the app to find support "
+            "through ANTSA.\n"
+            "Do NOT claim that a practitioner or care team is monitoring this "
+            "conversation — none exists.\n"
+            "In crisis situations, ALWAYS surface the crisis resources listed "
+            "above."
+        )
+
+    first_name = practitioner_info.get("firstName", "their practitioner")
+    pract_type = practitioner_info.get("practitionerType") or "practitioner"
+    is_b2c = practitioner_info.get("isB2c", False)
+
+    if is_b2c:
+        # Scenario B: B2C client who has connected with a practitioner
+        return (
+            "\n\n# PRACTITIONER CONTEXT\n"
+            f"This user has connected with {first_name}, a {pract_type} on "
+            "ANTSA.\n"
+            f"When suggesting professional support, mention {first_name} by "
+            "name as someone they can reach out to through the app.\n"
+            f'Example: "You might find it helpful to talk to {first_name}, '
+            f'your {pract_type} on ANTSA, about what you\'re going through."\n'
+            "In crisis situations, ALWAYS surface the crisis resources listed "
+            f"above first, then also suggest reaching out to {first_name} as "
+            "a follow-up once immediate safety is addressed."
+        )
+
+    # Scenario A: B2B — practitioner-assigned chat
+    return (
+        "\n\n# PRACTITIONER CONTEXT\n"
+        f"This user is working with {first_name}, their {pract_type}.\n"
+        f"When suggesting professional support, refer to {first_name} by "
+        "name rather than giving generic \"speak to a professional\" advice.\n"
+        f'Example: "I\'d encourage you to talk to {first_name}, your '
+        f'{pract_type}, about this."\n'
+        "In crisis situations, ALWAYS surface the crisis resources listed "
+        f"above first, then also suggest contacting {first_name} as a "
+        "follow-up once immediate safety is addressed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# API fetch
+# ---------------------------------------------------------------------------
+
+
+async def fetch_practitioner_context(
+    auth_token: str,
+    api_base_url: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch the authenticated client's practitioner context from the NestJS API.
+
+    Returns the JSON payload from GET /api/v1/gpt/client/practitioner-context,
+    or None on any failure (network, auth, 404, etc.).
+    """
+    base = api_base_url or os.getenv("NESTJS_API_URL", "http://localhost:8080")
+    url = f"{base}/api/v1/gpt/client/practitioner-context"
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {auth_token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            logger.warning(
+                "practitioner-context API returned %d: %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            return None
+    except Exception as exc:
+        logger.warning("practitioner-context fetch failed: %s", exc)
+        return None

--- a/tests/test_antsabot_companion_persona.py
+++ b/tests/test_antsabot_companion_persona.py
@@ -118,16 +118,20 @@ def test_companion_prompt_has_hardened_crisis_protocol():
     assert "emergency services" in lower
     # Self-harm / suicide handling is named.
     assert "self-harm" in lower or "suicide" in lower
-    # Never claims a human is monitoring / will be alerted.
-    assert "no practitioner" in lower or "no practitioner or care team" in lower
+    # Defers to PRACTITIONER CONTEXT for whether a practitioner exists;
+    # base prompt must not hardcode "no practitioner" but should reference
+    # the injected section.
+    assert "practitioner context" in lower or "no practitioner" in lower
 
 
 def test_companion_prompt_has_care_steering():
     """Gentle steering toward a professional + the in-app connect option."""
     prompt = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION).system_prompt
 
-    assert "Connect with your practitioner" in prompt
     lower = prompt.lower()
+    # Care-steering references the PRACTITIONER CONTEXT section for how to
+    # recommend professional support.
+    assert "practitioner context" in lower or "connect with a practitioner" in lower
     assert "mental health professional" in lower or "professional" in lower
     # Steering must be framed as gentle / non-pushy.
     assert "gentle" in lower or "non-pushy" in lower

--- a/tests/test_practitioner_context.py
+++ b/tests/test_practitioner_context.py
@@ -1,0 +1,224 @@
+"""
+Tests for practitioner-context injection into ANTSAbot personas.
+
+The companion and therapist personas previously gave generic "speak to a
+professional" advice. Now the system prompt is augmented with a PRACTITIONER
+CONTEXT block that names the client's practitioner (if any), so the model can
+give contextually appropriate recommendations.
+
+Three scenarios:
+  A) B2B practitioner-assigned chat — name the practitioner
+  B) B2C client who connected with a practitioner — name the practitioner
+  C) Pure B2C / no practitioner — suggest in-app "Connect with a practitioner"
+
+No pytest-asyncio dependency — follow the repo's asyncio.run pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from practitioner_context import (  # noqa: E402
+    build_practitioner_context_block,
+    fetch_practitioner_context,
+)
+from personas import PersonaType, persona_manager  # noqa: E402
+
+
+# --- build_practitioner_context_block unit tests ----------------------------
+
+
+def test_scenario_a_b2b_practitioner():
+    """Scenario A: B2B client has a named practitioner."""
+    block = build_practitioner_context_block({
+        "hasPractitioner": True,
+        "firstName": "Sally",
+        "practitionerType": "Psychologist",
+        "isB2c": False,
+    })
+    assert "PRACTITIONER CONTEXT" in block
+    assert "Sally" in block
+    assert "Psychologist" in block
+    # Should NOT suggest "Connect with a practitioner"
+    assert "Connect with a practitioner" not in block
+    # Should mention crisis resources as primary in crisis
+    assert "crisis" in block.lower()
+
+
+def test_scenario_b_b2c_with_practitioner():
+    """Scenario B: B2C client who has connected with a practitioner."""
+    block = build_practitioner_context_block({
+        "hasPractitioner": True,
+        "firstName": "James",
+        "practitionerType": "Counsellor",
+        "isB2c": True,
+    })
+    assert "PRACTITIONER CONTEXT" in block
+    assert "James" in block
+    assert "Counsellor" in block
+    assert "ANTSA" in block
+    assert "crisis" in block.lower()
+
+
+def test_scenario_c_no_practitioner():
+    """Scenario C: no practitioner — suggest in-app connection."""
+    block = build_practitioner_context_block({
+        "hasPractitioner": False,
+    })
+    assert "PRACTITIONER CONTEXT" in block
+    assert "Connect with a practitioner" in block
+    assert "Do NOT claim" in block
+    assert "crisis" in block.lower()
+
+
+def test_none_input_treated_as_no_practitioner():
+    """None input (fetch failed) falls back to no-practitioner scenario."""
+    block = build_practitioner_context_block(None)
+    assert "Connect with a practitioner" in block
+    assert "Do NOT claim" in block
+
+
+def test_missing_practitioner_type_uses_fallback():
+    """If practitionerType is missing/null, fall back to 'practitioner'."""
+    block = build_practitioner_context_block({
+        "hasPractitioner": True,
+        "firstName": "Alex",
+        "practitionerType": None,
+        "isB2c": False,
+    })
+    assert "Alex" in block
+    assert "practitioner" in block.lower()
+
+
+# --- persona prompt tests ---------------------------------------------------
+
+
+def test_companion_prompt_references_practitioner_context_section():
+    """The companion persona prompt tells the model to look for PRACTITIONER CONTEXT."""
+    base = persona_manager.get_persona(PersonaType.ANTSABOT_COMPANION).system_prompt
+    assert "PRACTITIONER CONTEXT" in base
+    # The old hardcoded "NO practitioner" claim must be gone.
+    assert "there is NO practitioner" not in base
+
+
+def test_therapist_prompt_references_practitioner_context_section():
+    """The therapist persona prompt tells the model to look for PRACTITIONER CONTEXT."""
+    base = persona_manager.get_persona(PersonaType.ANTSABOT_THERAPIST).system_prompt
+    assert "PRACTITIONER CONTEXT" in base
+
+
+# --- pipeline injection tests -----------------------------------------------
+
+
+class _StopForTest(Exception):
+    pass
+
+
+def _run_persona_prompt(persona_type, auth_token="fake-jwt", pract_response=None) -> str:
+    """
+    Drive generate_response_with_chaining far enough to capture the system
+    prompt handed to the pipeline, with all I/O stubbed. Returns the system
+    prompt string.
+    """
+    from haystack_pipeline import HaystackPipelineManager
+
+    mgr = HaystackPipelineManager()
+    mgr._initialized = True
+
+    captured = {}
+
+    def fake_convert(messages, system_prompt):
+        captured["system_prompt"] = system_prompt
+        raise _StopForTest()
+
+    fake_session = AsyncMock()
+    fake_session.context = {}
+    fake_session.profile_id = None
+    fake_session.auth_token = auth_token
+
+    async def mock_fetch(token, api_base_url=None):
+        return pract_response
+
+    async def drive():
+        with patch("haystack_pipeline.session_manager") as sm, \
+             patch.object(mgr, "_convert_to_haystack_messages", side_effect=fake_convert), \
+             patch("haystack_pipeline.fetch_practitioner_context", side_effect=mock_fetch):
+            sm.get_session = AsyncMock(return_value=fake_session)
+            sm.get_messages = AsyncMock(return_value=[])
+            sm.add_message = AsyncMock()
+            sm.create_session = AsyncMock()
+            try:
+                async for _ in mgr.generate_response_with_chaining(
+                    session_id="s-test",
+                    persona_type=persona_type,
+                    user_message="I feel really low",
+                    context={},
+                ):
+                    pass
+            except _StopForTest:
+                pass
+
+    asyncio.run(drive())
+    return captured.get("system_prompt", "")
+
+
+def test_companion_pipeline_injects_practitioner_with_name():
+    """Companion pipeline injects a named practitioner when one exists."""
+    prompt = _run_persona_prompt(
+        PersonaType.ANTSABOT_COMPANION,
+        pract_response={
+            "hasPractitioner": True,
+            "firstName": "Sally",
+            "practitionerType": "Psychologist",
+            "isB2c": False,
+        },
+    )
+    assert "PRACTITIONER CONTEXT" in prompt
+    assert "Sally" in prompt
+    assert "Psychologist" in prompt
+
+
+def test_companion_pipeline_injects_no_practitioner_fallback():
+    """Companion pipeline injects no-practitioner guidance when none exists."""
+    prompt = _run_persona_prompt(
+        PersonaType.ANTSABOT_COMPANION,
+        pract_response={"hasPractitioner": False},
+    )
+    assert "PRACTITIONER CONTEXT" in prompt
+    assert "Connect with a practitioner" in prompt
+
+
+def test_therapist_pipeline_injects_practitioner_context():
+    """Therapist pipeline also gets practitioner context."""
+    prompt = _run_persona_prompt(
+        PersonaType.ANTSABOT_THERAPIST,
+        pract_response={
+            "hasPractitioner": True,
+            "firstName": "James",
+            "practitionerType": "Counsellor",
+            "isB2c": False,
+        },
+    )
+    assert "PRACTITIONER CONTEXT" in prompt
+    assert "James" in prompt
+
+
+def test_web_assistant_not_affected():
+    """WEB_ASSISTANT persona should NOT get practitioner context injection."""
+    prompt = _run_persona_prompt(
+        PersonaType.WEB_ASSISTANT,
+        pract_response={
+            "hasPractitioner": True,
+            "firstName": "Sally",
+            "practitionerType": "Psychologist",
+            "isB2c": False,
+        },
+    )
+    # WEB_ASSISTANT should not have PRACTITIONER CONTEXT injected
+    # (the injection only runs for COMPANION and THERAPIST)
+    assert "Sally" not in prompt


### PR DESCRIPTION
## Summary
- Updates ANTSABOT_COMPANION and ANTSABOT_THERAPIST personas to reference a dynamically injected `PRACTITIONER CONTEXT` section instead of hardcoding "there is NO practitioner"
- Adds `practitioner_context.py` module: builds the prompt block and fetches practitioner data from the API
- Pipeline injects practitioner context alongside crisis resources for companion/therapist personas
- 11 new tests covering all three scenarios (B2B, B2C with practitioner, no practitioner) + pipeline injection + WEB_ASSISTANT not affected

**Companion PR:** antsa-pty-ltd/api#324 (API-side query, system prompt changes, new endpoint)

**Azure DevOps:** #200 — [Improvement] ANTSAbot recommendation language for professional help

## Test plan
- [x] All 48 Haystack tests pass (11 new + 37 existing)
- [x] Existing crisis resource tests still pass
- [x] Existing companion persona tests updated and passing
- [x] Verified end-to-end via mobile app with API companion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)