### PR TITLE
fix(pii): never interpolate real names into document prompts

### DIFF
--- a/document_generation/end_of_treatment.py
+++ b/document_generation/end_of_treatment.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from openai import OpenAI
 import os
 
+from pii_utils import is_tokenized, sanitize_for_logging, sanitize_dict_for_logging
+
 logger = logging.getLogger(__name__)
 
 class EndOfTreatmentGenerator:
@@ -79,8 +81,8 @@ Format the letter as a formal medical document."""
             return {
                 "letter": letter_content,
                 "metadata": {
-                    "client_name": f"{client_info.get('firstName')} {client_info.get('lastName')}",
-                    "practitioner_name": f"{practitioner_info.get('firstName')} {practitioner_info.get('lastName')}",
+                    "client_name": client_info.get('name', '[CLIENT_NAME]'),
+                    "practitioner_name": practitioner_info.get('name', '[PRACTITIONER_NAME]'),
                     "session_count": len(sessions),
                     "treatment_period": self._get_treatment_period(sessions),
                     "generated_at": datetime.now().isoformat()
@@ -100,14 +102,36 @@ Format the letter as a formal medical document."""
     ) -> str:
         """Build the prompt for GPT-4 letter generation"""
         
-        # Extract client details
-        client_name = f"{client_info.get('firstName')} {client_info.get('lastName')}"
+        # Extract client identifier.
+        # PRIVACY: The NestJS api sends a tokenized identifier (e.g. [CLIENT_NAME])
+        # in client_info['name']; the real name is substituted back only AFTER the
+        # LLM call. Use that token — do NOT concatenate firstName/lastName, which
+        # would leak real PII into the OpenAI prompt.
+        client_name = client_info.get('name', '[CLIENT_NAME]')
         client_age = client_info.get('age', 'N/A')
         client_gender = client_info.get('gender', 'N/A')
-        
-        # Extract practitioner details
-        practitioner_name = f"{practitioner_info.get('firstName')} {practitioner_info.get('lastName')}"
+
+        # Extract practitioner identifier (tokenized — see note above).
+        practitioner_name = practitioner_info.get('name', '[PRACTITIONER_NAME]')
         practitioner_title = practitioner_info.get('title', 'Clinical Psychologist')
+
+        # Defensive guard: if a real (untokenized) name slipped through from the
+        # caller, do NOT send it to OpenAI. Log a sanitized warning and degrade
+        # safely to the placeholder token. Never crash document generation.
+        if not is_tokenized(client_name):
+            logger.warning(
+                "⚠️ Untokenized client name reached end-of-treatment prompt builder; "
+                "replacing with [CLIENT_NAME]. client_info=%s",
+                sanitize_dict_for_logging(client_info),
+            )
+            client_name = "[CLIENT_NAME]"
+        if not is_tokenized(practitioner_name):
+            logger.warning(
+                "⚠️ Untokenized practitioner name reached end-of-treatment prompt builder; "
+                "replacing with [PRACTITIONER_NAME]. practitioner_info=%s",
+                sanitize_dict_for_logging(practitioner_info),
+            )
+            practitioner_name = "[PRACTITIONER_NAME]"
         
         # Get treatment period
         treatment_period = self._get_treatment_period(sessions)

--- a/document_generation/generator.py
+++ b/document_generation/generator.py
@@ -13,6 +13,8 @@ import logging
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
 
+from pii_utils import is_tokenized, sanitize_for_logging, sanitize_dict_for_logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,13 +50,34 @@ async def generate_document_from_context(
     """
     try:
         template_content = template.get('content', '')
-        client_name = client_info.get('name', 'Client')
-        practitioner_name = practitioner_info.get('name', 'Practitioner')
+        # PRIVACY: the NestJS api sends tokenized identifiers (e.g. [CLIENT_NAME],
+        # [PRACTITIONER_NAME]); real names are substituted back only AFTER this
+        # LLM call. Default to the tokens so a real name is never the fallback.
+        client_name = client_info.get('name', '[CLIENT_NAME]')
+        practitioner_name = practitioner_info.get('name', '[PRACTITIONER_NAME]')
+
+        # Defensive guard: if a real (untokenized) name slipped through, do NOT
+        # send it to OpenAI. Log a sanitized warning and degrade safely to the
+        # placeholder token. Never crash document generation.
+        if not is_tokenized(client_name):
+            logger.warning(
+                "⚠️ Untokenized client name reached document generator; "
+                "replacing with [CLIENT_NAME]. client_info=%s",
+                sanitize_dict_for_logging(client_info),
+            )
+            client_name = "[CLIENT_NAME]"
+        if not is_tokenized(practitioner_name):
+            logger.warning(
+                "⚠️ Untokenized practitioner name reached document generator; "
+                "replacing with [PRACTITIONER_NAME]. practitioner_info=%s",
+                sanitize_dict_for_logging(practitioner_info),
+            )
+            practitioner_name = "[PRACTITIONER_NAME]"
         today = datetime.now().strftime("%B %d, %Y")
         
         # Log detailed segment information for debugging
         unique_transcript_ids = set(seg.get('transcript_id', seg.get('transcriptId', 'unknown')) for seg in segments)
-        logger.info(f"🎨 Generating document: {len(segments)} segments from {len(unique_transcript_ids)} sessions, Client ID: '{client_info.get('id', 'unknown')}'")
+        logger.info(sanitize_for_logging(f"🎨 Generating document: {len(segments)} segments from {len(unique_transcript_ids)} sessions, Client ID: '{client_info.get('id', 'unknown')}'"))
         
         # Sort segments deterministically for consistent ordering
         # Sort by: transcript_id, start_time to ensure consistent document generation


### PR DESCRIPTION
## Problem
`document_generation/end_of_treatment.py` built its OpenAI prompt from **real** client/practitioner names (`firstName` + `lastName`) instead of the tokenized identifier the api sends — a PII leak (the path is currently unused, but a landmine).

## Fix
- Use the `[CLIENT_NAME]` / `[PRACTITIONER_NAME]` tokens, matching `generator.py`.
- Wire `pii_utils` (previously dead code) as a **defensive guard** in `generator.py` and `end_of_treatment.py`: `is_tokenized()` checks each name field before the prompt is built; an untokenized value is logged (sanitized) and degraded to the placeholder token rather than sent to OpenAI.
- Missing-name fallbacks default to tokens; client info in logs is sanitized.

In practice the api already sends `[CLIENT_NAME]`, so the guards are no-ops on the happy path — this is defense-in-depth.

## Verification
- `python -m py_compile` passes on changed files + `pii_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)