### PR TITLE
ci: align source-branch check name with master-protection ruleset

### DIFF
--- a/.github/workflows/source-branch-check.yml
+++ b/.github/workflows/source-branch-check.yml
@@ -9,7 +9,11 @@ on:
 
 jobs:
   develop-only:
-    name: develop-only
+    # Job display name MUST equal the required status-check context in the
+    # master-protection ruleset ("Source branch / develop-only"), matching the
+    # web/api repos. A mismatch leaves the required check stuck "Expected" and
+    # blocks develop→master promotion PRs.
+    name: Source branch / develop-only
     runs-on: ubuntu-latest
     steps:
       - name: Verify source branch is develop


### PR DESCRIPTION
## Problem
develop→master promotion PRs (e.g. #79) get stuck: the master-protection ruleset requires the status check `Source branch / develop-only`, but this repo's job reports its context as `develop-only`. A required context that's never reported sits "Expected — waiting for status to be reported" forever.

## Fix
Rename the job's display name `develop-only` → `Source branch / develop-only`, matching what the ruleset requires (and the convention `web`/`api` already follow). One-line change.

## ⚠️ Not fully unblocked by this PR
master-protection **also** requires `staging-smoke`, which **no haystack workflow produces** (staging-smoke lives in the *infra* repo). That required check must be **removed from the ruleset by a repo admin** — it cannot be satisfied by code here. See haystack issue #78-adjacent / the PR #79 comment for the exact ruleset edits.

After both this rename **and** the admin removing `staging-smoke`, promotion PRs will resolve cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)