### PR TITLE
chore(security): add Dependabot (pip + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Python dependencies (requirements.txt) — weekly version-update PRs into
+  # develop. Minor/patch grouped into one PR; majors come individually so
+  # breaking upgrades can be reviewed/tested on their own.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      pip-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep GitHub Actions pinned versions current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    open-pull-requests-limit: 5
+    labels:
+      - "ci"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to automate ongoing dependency hygiene (security-audit follow-up).

- **pip** version-update PRs into `develop`, weekly — minor/patch grouped into one PR, majors individual so breaking upgrades are reviewed alone.
- **github-actions** version updates, weekly.

Security-update PRs (when a CVE is published) are raised automatically by Dependabot against the default branch once this config is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)